### PR TITLE
feat: shared header/footer partials (layout inject)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,13 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Verify layout HTML matches partials
+        run: |
+          node scripts/inject-layout.mjs
+          git diff --exit-code -- '*.html' || (
+            echo "::error::Layout drift: run npm run build:layout and commit the updated HTML files."
+            exit 1
+          )
+
       - name: Run unit tests
         run: node --test tests/sync-events.spec.mjs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify HTML matches layout partials
+        run: |
+          node scripts/inject-layout.mjs
+          git diff --exit-code -- '*.html' || (
+            echo "::error::Layout drift: edit includes/site-header.html / site-footer.html, then run npm run build:layout and commit."
+            exit 1
+          )
+
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
@@ -75,6 +83,9 @@ jobs:
           for f in events-data.json feed.xml funding.json sitemap.xml; do
             [ -f "/tmp/_live_$f" ] && cp "/tmp/_live_$f" "$f"
           done
+
+      - name: Apply layout partials to HTML
+        run: node scripts/inject-layout.mjs
 
       - name: Cache-bust asset references
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Project conventions for contributors and Claude Code.
 ## What this is
 
 Static website for [bitcircus101](https://bitcircus101.de), a hackspace in Bonn.
-Pure HTML/CSS/JS — no build step, no framework.
+Pure HTML/CSS/JS — **no bundler, no framework.** Shared site chrome (nav + footer) uses `includes/*.html` plus a one-shot **`npm run build:layout`** (see [Shared layout](#shared-layout)); everything else is edited directly.
 
 ## Branches
 
@@ -28,12 +28,12 @@ Pure HTML/CSS/JS — no build step, no framework.
 ### How CI works
 
 ```
-PR to main  →  Unit tests only (fast, no Playwright)
+PR to main  →  Unit tests + layout sync check (fast, no Playwright)
 Push to main  →  Full suite (unit + E2E × 2 browsers)  →  Deploy to live
 ```
 
-Tests gate deployment, not contribution. A PR with failing unit tests gets flagged,
-but the heavy Playwright suite only runs after merge — before anything reaches production.
+Tests gate deployment, not contribution. A PR with failing unit tests or layout drift gets flagged.
+The heavy Playwright suite runs after merge to `main` — before anything reaches production.
 
 ### For AI agents
 
@@ -55,10 +55,21 @@ npx http-server . -p 8080
 
 Open `http://localhost:8080` in your browser. That's it.
 
+## Shared layout
+
+| Item | Role |
+|------|------|
+| `includes/site-header.html` | Single source for `<header>` / nav |
+| `includes/site-footer.html` | Single source for `<footer>` |
+| `scripts/inject-layout.mjs` | Inlines those into the six layout HTML files |
+| `npm run build:layout` | Run after editing the partials |
+
+**Workflow:** Edit the partials → `npm run build:layout` → commit partials **and** changed `*.html`. CI runs `inject-layout.mjs` and fails if there is any `git diff` on HTML (drift). Deploy also runs inject before cache-busting so `live` stays aligned.
+
 ## Code conventions
 
 - German UI text, English code comments
-- No build tools, no bundlers — edit HTML/CSS/JS directly
+- No bundlers — edit HTML/CSS/JS directly (except running `npm run build:layout` when you touch `includes/*.html`)
 - Terminal aesthetic: dark background, green accent, monospace font
 - No Google Fonts or external font loading (privacy)
 - No inline styles — everything in `style.css`
@@ -79,6 +90,6 @@ Add an entry to `calendars.json` — no code changes needed.
 ## Adding a new page
 
 1. Create the HTML file
-2. Add navigation links in other pages
+2. Add the nav link in `includes/site-header.html`, run `npm run build:layout`, and commit the updated partial + HTML files (or register the page in `scripts/inject-layout.mjs` if it should share the same chrome)
 3. Add the page to the `pages` array in `tests/site.spec.js` (no-JS-errors test)
 4. Sitemap is auto-generated on deploy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,22 @@ npm install
 npm run test:quick    # ~100ms, no browser needed
 ```
 
+That runs unit tests and matches what PR CI enforces (plus a layout sync check — see below).
+
+## Navigation and footer (shared layout)
+
+Header and footer live in **`includes/site-header.html`** and **`includes/site-footer.html`**. A small Node script copies them into the layout HTML files — no bundler or framework.
+
+After you change those files:
+
+```sh
+npm run build:layout
+```
+
+Commit **`includes/`** and the updated **`*.html`** files together. **PR checks** fail if partials and pages drift apart. See [CLAUDE.md](CLAUDE.md) for details.
+
+If you only edit a page body, you do not need `build:layout`.
+
 ## You do NOT need to
 
 - Install Playwright or any browsers
@@ -28,7 +44,7 @@ CI handles the heavy testing automatically.
 
 ## What happens when you open a PR
 
-1. **CI runs unit tests** — fast, automatic, done in seconds
+1. **CI runs unit tests and checks layout HTML** — fast, automatic, done in seconds (no Playwright)
 2. **A maintainer reviews** your PR
 3. **On merge to main** — the full E2E test suite runs automatically (Playwright, 2 browsers)
 4. **If all tests pass** — your changes go live at [bitcircus101.de](https://bitcircus101.de)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ donations.html              Donation / funding page (loads funding.json)
 raum-nutzen.html            Room usage info
 impressum-datenschutz.html  Legal / privacy
 dankedankedanke.html        Thank you page
+
+includes/
+  site-header.html          Shared <header> (nav); inlined into pages by build:layout
+  site-footer.html          Shared <footer>; inlined into pages by build:layout
+scripts/inject-layout.mjs   Writes header/footer into the six layout HTML files
+
 style.css                   Global styles (terminal theme, dark bg, green accent)
 
 events.js                   Frontend: fetches events-data.json, renders event cards, tag filtering
@@ -35,6 +41,7 @@ tests/
 playwright.config.js        Playwright config (Chromium, Mobile Chrome)
 
 .github/workflows/
+  ci.yml                    PR checks: layout sync + unit tests (no Playwright)
   deploy.yml                Test on main → deploy to live
   sync-events.yml           Calendar sync (every 15 min)
   update-funding.yml        Funding level update (manual)
@@ -61,12 +68,13 @@ main (push) → Unit tests → Sync script → Playwright E2E → Deploy to live
 ```
 
 Every push to `main` triggers:
-1. **Unit tests:** ICS parser, RRULE expansion, date parsing (node:test, 22 tests)
-2. **Sync script:** Generates `events-data.json` for E2E tests to use
-3. **E2E tests:** Playwright across 2 browsers (~20 tests × Chromium + Mobile Chrome)
-4. **Deploy** (only if all tests pass): Syncs site files from `main` to `live`
+1. **Layout sync check:** `scripts/inject-layout.mjs` must not change any committed `*.html`
+2. **Unit tests:** ICS parser, RRULE expansion, date parsing (node:test)
+3. **Sync script:** Generates `events-data.json` for E2E tests to use
+4. **E2E tests:** Playwright across 2 browsers (~20 tests × Chromium + Mobile Chrome)
+5. **Deploy** (only if all tests pass): Syncs site files from `main` to `live`
 
-PRs get lightweight CI (unit tests only) via `ci.yml`.
+PRs get lightweight CI via [`ci.yml`](.github/workflows/ci.yml): same layout check + unit tests (no Playwright). See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Nothing reaches production without passing all tests first.
 
@@ -134,6 +142,8 @@ If no tags match, the event gets `#community` as default.
 - Permalink anchors with smooth scroll
 
 ## Local development
+
+**Site chrome (nav + footer):** Edit [`includes/site-header.html`](includes/site-header.html) and [`includes/site-footer.html`](includes/site-footer.html), then run `npm run build:layout` and commit the partials plus updated `*.html`. Documented in [CONTRIBUTING.md](CONTRIBUTING.md) and [CLAUDE.md](CLAUDE.md).
 
 Static site — open HTML files directly or use any local server:
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Unreleased
+
+- **Layout partials:** Shared site header and footer live in `includes/site-header.html` and `includes/site-footer.html`. Run `npm run build:layout` (or `node scripts/inject-layout.mjs`) to apply them to all six layout pages. Deploy reapplies partials before cache-busting; CI on PR and on push to `main` fails if committed HTML drifts from the partials.
+- **Docs:** [CONTRIBUTING.md](CONTRIBUTING.md), [CLAUDE.md](CLAUDE.md), and [README.md](README.md) describe the layout workflow; PR checks ([`ci.yml`](.github/workflows/ci.yml)) run the layout sync check plus unit tests.

--- a/includes/site-footer.html
+++ b/includes/site-footer.html
@@ -1,0 +1,17 @@
+<footer role="contentinfo" class="footer">
+    <div class="footer__grid">
+        <div class="footer__col">
+            <span class="footer__brand">bitcircus101</span>
+            <span class="footer__tagline">Hackspace · Bonn · Dorotheenstraße 101</span>
+        </div>
+        <div class="footer__col footer__col--links">
+            <a href="https://github.com/bmmmm/bitcircus101" target="_blank" rel="noopener">github ↗</a>
+            <a href="impressum-datenschutz.html">impressum</a>
+        </div>
+    </div>
+    <div class="footer__bar">
+        <span class="footer__year"></span>
+        <span class="footer__sep">·</span>
+        <span class="footer__status">lights: on</span>
+    </div>
+</footer>

--- a/includes/site-header.html
+++ b/includes/site-header.html
@@ -1,0 +1,24 @@
+<header>
+    <nav id="main-nav" aria-label="Hauptnavigation">
+        <a class="nav__brand" href="index.html">
+            <span class="nav__prompt">&gt;_</span>
+            <span class="nav__name">bitcircus101</span>
+        </a>
+        <button
+            class="menu-toggle"
+            id="menu-toggle"
+            aria-controls="main-nav"
+            aria-expanded="false"
+        >
+            ☰ Menü
+        </button>
+        <ul>
+            <li><a href="index.html#about">Über uns</a></li>
+            <li><a href="events.html">Veranstaltungen</a></li>
+            <li><a href="raum-nutzen.html">Raum nutzen</a></li>
+            <li><a href="donations.html" class="nav__cta">Unterstützen</a></li>
+            <li><a href="index.html#contact">Kontakt</a></li>
+            <li><a href="feed.xml" class="nav__rss" title="RSS Feed">&#9673;</a></li>
+        </ul>
+    </nav>
+</header>

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "build:layout": "node scripts/inject-layout.mjs",
+    "build": "npm run build:layout",
     "test": "node --test tests/sync-events.spec.mjs && playwright test",
     "test:quick": "node --test tests/sync-events.spec.mjs",
     "test:unit": "node --test tests/sync-events.spec.mjs",

--- a/scripts/inject-layout.mjs
+++ b/scripts/inject-layout.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * Inline includes/site-header.html and includes/site-footer.html into each
+ * allowlisted page. Edit the partials, then run: npm run build:layout
+ */
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(__dirname, "..");
+
+const LAYOUT_PAGES = [
+  "index.html",
+  "events.html",
+  "donations.html",
+  "raum-nutzen.html",
+  "impressum-datenschutz.html",
+  "dankedankedanke.html",
+];
+
+/** Prepend the same indent used for direct children of <body> (8 spaces in this site). */
+function withBodyIndent(fragment, indent = "        ") {
+  return fragment
+    .trim()
+    .split("\n")
+    .map((line) => (line.length ? indent + line : ""))
+    .join("\n");
+}
+
+/**
+ * Replace the first top-level <tagName>...</tagName> block (case-insensitive tag name).
+ */
+function replaceFirstBlock(html, tagName, replacement) {
+  const lower = html.toLowerCase();
+  const openNeedle = `<${tagName.toLowerCase()}`;
+  const start = lower.indexOf(openNeedle);
+  if (start === -1) {
+    throw new Error(`Missing <${tagName}> in file`);
+  }
+  const openEnd = html.indexOf(">", start);
+  if (openEnd === -1) {
+    throw new Error(`Unclosed opening <${tagName}> tag`);
+  }
+  const closeNeedle = `</${tagName.toLowerCase()}>`;
+  const closeStart = lower.indexOf(closeNeedle, openEnd + 1);
+  if (closeStart === -1) {
+    throw new Error(`Missing </${tagName}> in file`);
+  }
+  const end = closeStart + closeNeedle.length;
+  const lineStart = html.lastIndexOf("\n", start - 1) + 1;
+  const insert = withBodyIndent(replacement);
+  let rest = html.slice(end);
+  if (rest.length && !rest.startsWith("\n")) {
+    rest = "\n" + rest;
+  }
+  return html.slice(0, lineStart) + insert + rest;
+}
+
+function main() {
+  const headerPath = path.join(root, "includes", "site-header.html");
+  const footerPath = path.join(root, "includes", "site-footer.html");
+  const header = fs.readFileSync(headerPath, "utf8");
+  const footer = fs.readFileSync(footerPath, "utf8");
+
+  for (const name of LAYOUT_PAGES) {
+    const filePath = path.join(root, name);
+    let html = fs.readFileSync(filePath, "utf8");
+    html = replaceFirstBlock(html, "header", header);
+    html = replaceFirstBlock(html, "footer", footer);
+    fs.writeFileSync(filePath, html, "utf8");
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds `includes/site-header.html` and `includes/site-footer.html` as the single source for nav + footer, with `scripts/inject-layout.mjs` and `npm run build:layout` to inline them into the six layout pages.

## Docs
- CONTRIBUTING.md and CLAUDE.md: layout workflow, PR CI, adding pages.
- README: `ci.yml` + deploy layout steps.
- changelog.md (Unreleased).

## CI
- **PR (`ci.yml`):** layout drift check + unit tests.
- **Push to main (`deploy.yml`):** layout check before Playwright; deploy reapplies partials before cache-bust.

Contributors editing chrome run `npm run build:layout` and commit partials + HTML.