### PR TITLE
feat: add /join-info and /join-talk Signal redirect aliases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,7 +122,7 @@ jobs:
           echo "Asset hash: $HASH"
           # Replace ?v=anything with ?v=<hash> in all HTML files
           sed -i "s/?v=[a-zA-Z0-9_-]*/?v=$HASH/g" *.html
-          for d in ascii chat invite-info invite-talk; do
+          for d in ascii chat invite-info invite-talk join-info join-talk; do
             for f in "$d"/*.html; do
               [ -f "$f" ] && sed -i "s/?v=[a-zA-Z0-9_-]*/?v=$HASH/g" "$f"
             done

--- a/join-info/index.html
+++ b/join-info/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="de">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="robots" content="noindex, nofollow" />
+        <meta http-equiv="refresh" content="0;url=https://signal.group/#CjQKIE1y0qxqFK3-s2iaAfKoRpPr0d0SJ5xfo1CYx1i0OL3HEhBCwWp72gxe7qpDnikgHwmc" />
+        <title>Signal INFO – bitcircus101</title>
+    </head>
+    <body>
+        <script>
+            window.location.replace('https://signal.group/#CjQKIE1y0qxqFK3-s2iaAfKoRpPr0d0SJ5xfo1CYx1i0OL3HEhBCwWp72gxe7qpDnikgHwmc');
+        </script>
+        <p>Weiterleitung zur Signal-Gruppe… <a href="https://signal.group/#CjQKIE1y0qxqFK3-s2iaAfKoRpPr0d0SJ5xfo1CYx1i0OL3HEhBCwWp72gxe7qpDnikgHwmc">direkt öffnen</a></p>
+    </body>
+</html>

--- a/join-talk/index.html
+++ b/join-talk/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="de">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="robots" content="noindex, nofollow" />
+        <meta http-equiv="refresh" content="0;url=https://signal.group/#CjQKIMlB_MPoq8u3B8dJMsoObtvYyPSdQQhQV2c99VBOEfEOEhBOskl_noYniXrJpnQepOXF" />
+        <title>Signal TALK – bitcircus101</title>
+    </head>
+    <body>
+        <script>
+            window.location.replace('https://signal.group/#CjQKIMlB_MPoq8u3B8dJMsoObtvYyPSdQQhQV2c99VBOEfEOEhBOskl_noYniXrJpnQepOXF');
+        </script>
+        <p>Weiterleitung zur Signal-Gruppe… <a href="https://signal.group/#CjQKIMlB_MPoq8u3B8dJMsoObtvYyPSdQQhQV2c99VBOEfEOEhBOskl_noYniXrJpnQepOXF">direkt öffnen</a></p>
+    </body>
+</html>

--- a/robots.txt
+++ b/robots.txt
@@ -5,9 +5,11 @@ User-agent: *
 Allow: /
 # Internal ASCII playground (no nav link, noindex in page)
 Disallow: /ascii/
-# Signal invite redirects – noindex pages, no need to crawl
+# Signal invite/join redirects – noindex pages, no need to crawl
 Disallow: /invite-info/
 Disallow: /invite-talk/
+Disallow: /join-info/
+Disallow: /join-talk/
 
 Sitemap: https://bitcircus101.de/sitemap.xml
 
@@ -17,51 +19,69 @@ Allow: /
 Disallow: /ascii/
 Disallow: /invite-info/
 Disallow: /invite-talk/
+Disallow: /join-info/
+Disallow: /join-talk/
 
 User-agent: Google-Extended
 Allow: /
 Disallow: /ascii/
 Disallow: /invite-info/
 Disallow: /invite-talk/
+Disallow: /join-info/
+Disallow: /join-talk/
 
 User-agent: ClaudeBot
 Allow: /
 Disallow: /ascii/
 Disallow: /invite-info/
 Disallow: /invite-talk/
+Disallow: /join-info/
+Disallow: /join-talk/
 
 User-agent: anthropic-ai
 Allow: /
 Disallow: /ascii/
 Disallow: /invite-info/
 Disallow: /invite-talk/
+Disallow: /join-info/
+Disallow: /join-talk/
 
 User-agent: Amazonbot
 Allow: /
 Disallow: /ascii/
 Disallow: /invite-info/
 Disallow: /invite-talk/
+Disallow: /join-info/
+Disallow: /join-talk/
 
 User-agent: CCBot
 Allow: /
 Disallow: /ascii/
 Disallow: /invite-info/
 Disallow: /invite-talk/
+Disallow: /join-info/
+Disallow: /join-talk/
 
 User-agent: PerplexityBot
 Allow: /
 Disallow: /ascii/
 Disallow: /invite-info/
 Disallow: /invite-talk/
+Disallow: /join-info/
+Disallow: /join-talk/
 
 User-agent: YouBot
 Allow: /
 Disallow: /ascii/
 Disallow: /invite-info/
 Disallow: /invite-talk/
+Disallow: /join-info/
+Disallow: /join-talk/
 
 User-agent: Applebot-Extended
 Allow: /
 Disallow: /ascii/
 Disallow: /invite-info/
 Disallow: /invite-talk/
+Disallow: /join-info/
+Disallow: /join-talk/


### PR DESCRIPTION
Mirror of /invite-info und /invite-talk — kürzere URLs zum Teilen. robots.txt + deploy.yml aktualisiert.