### PR TITLE
feat(theme): calm theme toggle + cleanup

### DIFF
--- a/ascii/index.html
+++ b/ascii/index.html
@@ -11,7 +11,11 @@
             content="Interner ASCII-Spielplatz für bitcircus101 – nicht in der Navigation verlinkt."
         />
         <link rel="icon" type="image/svg+xml" href="../images/favicon.svg" />
-        <link rel="stylesheet" href="../style.css?v=5" />
+        <script>
+            // No-flash: apply persisted calm theme before stylesheet paints.
+            try { if (localStorage.getItem("theme") === "calm") document.documentElement.dataset.theme = "calm"; } catch (e) {}
+        </script>
+        <link rel="stylesheet" href="../style.css?v=6" />
     </head>
     <body class="ascii-playground-body">
         <a class="skip-link" href="#main-content">Zum Inhalt springen</a>

--- a/chat/index.html
+++ b/chat/index.html
@@ -19,7 +19,11 @@
         <meta property="og:locale" content="de_DE" />
         <link rel="canonical" href="https://bitcircus101.de/chat/" />
         <link rel="icon" type="image/svg+xml" href="../images/favicon.svg" />
-        <link rel="stylesheet" href="../style.css?v=5" />
+        <script>
+            // No-flash: apply persisted calm theme before stylesheet paints.
+            try { if (localStorage.getItem("theme") === "calm") document.documentElement.dataset.theme = "calm"; } catch (e) {}
+        </script>
+        <link rel="stylesheet" href="../style.css?v=6" />
     </head>
     <body class="chat-page">
         <a class="skip-link" href="#main-content">Zum Inhalt springen</a>

--- a/dankedankedanke.html
+++ b/dankedankedanke.html
@@ -12,7 +12,11 @@
         <meta property="og:description" content="Dein Beitrag hält den Hackspace am Laufen. Danke!" />
         <meta property="og:image" content="https://bitcircus101.de/images/og-image.jpg" />
         <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
-        <link rel="stylesheet" href="style.css?v=5" />
+        <script>
+            // No-flash: apply persisted calm theme before stylesheet paints.
+            try { if (localStorage.getItem("theme") === "calm") document.documentElement.dataset.theme = "calm"; } catch (e) {}
+        </script>
+        <link rel="stylesheet" href="style.css?v=6" />
     </head>
     <body>
         <a class="skip-link" href="#main-content">Zum Inhalt springen</a>
@@ -39,6 +43,7 @@
                     <li><a href="donations.html" class="nav__cta">Unterstützen</a></li>
                     <li><a href="index.html#contact">Kontakt</a></li>
                     <li><a href="feed.xml" class="nav__rss" title="RSS Feed" aria-label="RSS-Feed der Termine">&#9673; RSS</a></li>
+                    <li><button type="button" class="theme-toggle" id="theme-toggle" aria-pressed="false" aria-label="Ruhiges Design umschalten" title="Ruhiges Design (calm)">calm</button></li>
                 </ul>
             </nav>
         </header>
@@ -94,6 +99,6 @@
                 });
             });
         </script>
-        <script defer src="main.js?v=7"></script>
+        <script defer src="main.js?v=8"></script>
     </body>
 </html>

--- a/donations.html
+++ b/donations.html
@@ -32,7 +32,11 @@
         <meta name="twitter:image" content="https://bitcircus101.de/images/og-image.jpg" />
         <link rel="canonical" href="https://bitcircus101.de/donations.html" />
         <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
-        <link rel="stylesheet" href="style.css?v=5" />
+        <script>
+            // No-flash: apply persisted calm theme before stylesheet paints.
+            try { if (localStorage.getItem("theme") === "calm") document.documentElement.dataset.theme = "calm"; } catch (e) {}
+        </script>
+        <link rel="stylesheet" href="style.css?v=6" />
     </head>
     <body>
         <a class="skip-link" href="#main-content">Zum Inhalt springen</a>
@@ -96,6 +100,7 @@
                     <li><a href="donations.html" class="nav__cta">Unterstützen</a></li>
                     <li><a href="index.html#contact">Kontakt</a></li>
                     <li><a href="feed.xml" class="nav__rss" title="RSS Feed" aria-label="RSS-Feed der Termine">&#9673; RSS</a></li>
+                    <li><button type="button" class="theme-toggle" id="theme-toggle" aria-pressed="false" aria-label="Ruhiges Design umschalten" title="Ruhiges Design (calm)">calm</button></li>
                 </ul>
             </nav>
         </header>
@@ -346,6 +351,6 @@
                 });
             })();
         </script>
-        <script defer src="main.js?v=7"></script>
+        <script defer src="main.js?v=8"></script>
     </body>
 </html>

--- a/events.html
+++ b/events.html
@@ -31,7 +31,11 @@
         <link rel="canonical" href="https://bitcircus101.de/events.html" />
         <link rel="alternate" type="application/rss+xml" title="bitcircus101 Termine" href="feed.xml" />
         <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
-        <link rel="stylesheet" href="style.css?v=5" />
+        <script>
+            // No-flash: apply persisted calm theme before stylesheet paints.
+            try { if (localStorage.getItem("theme") === "calm") document.documentElement.dataset.theme = "calm"; } catch (e) {}
+        </script>
+        <link rel="stylesheet" href="style.css?v=6" />
     </head>
     <body>
         <a class="skip-link" href="#main-content">Zum Inhalt springen</a>
@@ -58,6 +62,7 @@
                     <li><a href="donations.html" class="nav__cta">Unterstützen</a></li>
                     <li><a href="index.html#contact">Kontakt</a></li>
                     <li><a href="feed.xml" class="nav__rss" title="RSS Feed" aria-label="RSS-Feed der Termine">&#9673; RSS</a></li>
+                    <li><button type="button" class="theme-toggle" id="theme-toggle" aria-pressed="false" aria-label="Ruhiges Design umschalten" title="Ruhiges Design (calm)">calm</button></li>
                 </ul>
             </nav>
         </header>
@@ -148,8 +153,8 @@
                 <span class="footer__status">lights: on</span>
             </div>
         </footer>
-        <script defer src="events.js?v=6"></script>
-        <script defer src="main.js?v=7"></script>
+        <script defer src="events.js?v=7"></script>
+        <script defer src="main.js?v=8"></script>
         <script>
             document.getElementById("linkup-info-btn").addEventListener("click", function() {
                 var panel = document.getElementById("linkup-info-panel");

--- a/events.js
+++ b/events.js
@@ -41,6 +41,15 @@
       .replace(/"/g, "&quot;");
   }
 
+  // Bare-domain URLs (e.g. "bitcircus101.de") would render as a relative href
+  // and 404. Prepend https:// when neither a scheme nor a root-relative path is
+  // present. Mirrors the sync-side normalization in sync-events.mjs (5ee7f07).
+  function httpUrl(u) {
+    if (!u) return u;
+    if (u.charAt(0) === "/" || /^[a-z][\w+.-]*:\/\//i.test(u)) return u;
+    return "https://" + u;
+  }
+
   function isBitcircusEvent(e) {
     return !e.source || e.source === "bitcircus101";
   }
@@ -297,8 +306,8 @@
         // External event URLs (e.g. Kult 41) link directly; Nextcloud calendar URLs
         // get the timeGridDay suffix for day view
         var calHref = e.eventUrl
-          ? e.eventUrl
-          : (e.calendarUrl || CALENDAR_URL) + '/timeGridDay/' + e.date;
+          ? httpUrl(e.eventUrl)
+          : httpUrl(e.calendarUrl || CALENDAR_URL) + '/timeGridDay/' + e.date;
         var calLabel = e.eventUrl ? '\u2192 link' : '\u2192 kalender';
         var calTitle = e.eventUrl ? 'Auf externer Seite \u00f6ffnen' : 'Im Kalender anzeigen';
         html += '<div class="event-card__actions">';

--- a/events.js
+++ b/events.js
@@ -41,13 +41,6 @@
       .replace(/"/g, "&quot;");
   }
 
-  function formatSourceLabel(name) {
-    if (name && name !== "bitcircus101") {
-      return "Externer Kalender: " + name;
-    }
-    return name;
-  }
-
   function isBitcircusEvent(e) {
     return !e.source || e.source === "bitcircus101";
   }
@@ -271,7 +264,7 @@
         html += '<h3 class="event-card__title">' + esc(e.title) + "</h3>";
         if (e.source && e.source !== "bitcircus101") {
           html += '<span class="event-card__source">' +
-            esc(formatSourceLabel(e.source)) + "</span>";
+            esc("Externer Kalender: " + e.source) + "</span>";
         }
         html += "</div>";
         if (e.subtitle) {

--- a/impressum-datenschutz.html
+++ b/impressum-datenschutz.html
@@ -37,7 +37,11 @@
             href="https://bitcircus101.de/impressum-datenschutz.html"
         />
         <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
-        <link rel="stylesheet" href="style.css?v=5" />
+        <script>
+            // No-flash: apply persisted calm theme before stylesheet paints.
+            try { if (localStorage.getItem("theme") === "calm") document.documentElement.dataset.theme = "calm"; } catch (e) {}
+        </script>
+        <link rel="stylesheet" href="style.css?v=6" />
     </head>
     <body>
         <a class="skip-link" href="#main-content">Zum Inhalt springen</a>
@@ -64,6 +68,7 @@
                     <li><a href="donations.html" class="nav__cta">Unterstützen</a></li>
                     <li><a href="index.html#contact">Kontakt</a></li>
                     <li><a href="feed.xml" class="nav__rss" title="RSS Feed" aria-label="RSS-Feed der Termine">&#9673; RSS</a></li>
+                    <li><button type="button" class="theme-toggle" id="theme-toggle" aria-pressed="false" aria-label="Ruhiges Design umschalten" title="Ruhiges Design (calm)">calm</button></li>
                 </ul>
             </nav>
         </header>
@@ -241,7 +246,7 @@
                 <span class="footer__status">lights: on</span>
             </div>
         </footer>
-        <script defer src="main.js?v=7"></script>
+        <script defer src="main.js?v=8"></script>
         <script>
             document.getElementById("current-date").textContent =
                 new Date().toLocaleDateString("de-DE", {

--- a/includes/site-header.html
+++ b/includes/site-header.html
@@ -21,6 +21,7 @@
             <li><a href="donations.html" class="nav__cta">Unterstützen</a></li>
             <li><a href="index.html#contact">Kontakt</a></li>
             <li><a href="feed.xml" class="nav__rss" title="RSS Feed" aria-label="RSS-Feed der Termine">&#9673; RSS</a></li>
+            <li><button type="button" class="theme-toggle" id="theme-toggle" aria-pressed="false" aria-label="Ruhiges Design umschalten" title="Ruhiges Design (calm)">calm</button></li>
         </ul>
     </nav>
 </header>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,11 @@
         />
         <meta name="referrer" content="no-referrer-when-downgrade" />
         <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
-        <link rel="stylesheet" href="style.css?v=5" />
+        <script>
+            // No-flash: apply persisted calm theme before stylesheet paints.
+            try { if (localStorage.getItem("theme") === "calm") document.documentElement.dataset.theme = "calm"; } catch (e) {}
+        </script>
+        <link rel="stylesheet" href="style.css?v=6" />
 
         <!-- Structured Data -->
         <script type="application/ld+json">
@@ -124,6 +128,7 @@
                     <li><a href="donations.html" class="nav__cta">Unterstützen</a></li>
                     <li><a href="index.html#contact">Kontakt</a></li>
                     <li><a href="feed.xml" class="nav__rss" title="RSS Feed" aria-label="RSS-Feed der Termine">&#9673; RSS</a></li>
+                    <li><button type="button" class="theme-toggle" id="theme-toggle" aria-pressed="false" aria-label="Ruhiges Design umschalten" title="Ruhiges Design (calm)">calm</button></li>
                 </ul>
             </nav>
         </header>
@@ -466,7 +471,7 @@
             </div>
         </footer>
 
-        <script defer src="main.js?v=7"></script>
+        <script defer src="main.js?v=8"></script>
         <script>
         (function () {
             var el = document.getElementById('signal-decode-result');

--- a/index.html
+++ b/index.html
@@ -471,7 +471,8 @@
         (function () {
             var el = document.getElementById('signal-decode-result');
             if (!el) return;
-            if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+            if (document.documentElement.dataset.theme === 'calm' ||
+                window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
                 el.textContent = 'SIGNAL CHATS';
                 return;
             }

--- a/main.js
+++ b/main.js
@@ -219,7 +219,7 @@
       this.elements.dots.forEach((dot, index) => {
         utils.addEventListenerSafe(dot, "click", (e) => {
           utils.preventDefaultAndStop(e);
-          this.goToSlide(index);
+          this.showSlide(index);
           this.resetAutoRotateIfEnabled();
         });
       });
@@ -295,10 +295,6 @@
         (this.state.current - 1 + this.elements.items.length) %
         this.elements.items.length;
       this.showSlide(prevIndex);
-    },
-
-    goToSlide(index) {
-      this.showSlide(index);
     },
 
     startAutoRotate() {

--- a/main.js
+++ b/main.js
@@ -31,6 +31,16 @@
     },
   };
 
+  // True when the user wants calm motion: explicit calm theme OR OS reduced-motion.
+  // Single source of truth for all JS-driven motion (carousel, matrix trail, scramble).
+  function prefersCalm() {
+    if (document.documentElement.dataset.theme === "calm") return true;
+    return !!(
+      window.matchMedia &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    );
+  }
+
   // =============================================================================
   // Navigation Module
   // =============================================================================
@@ -169,7 +179,20 @@
       this.cacheElements();
       this.bindEvents();
       this.showSlide(this.state.current);
-      this.startAutoRotate();
+      this.applyMotionPreference();
+    },
+
+    // Auto-rotate only when the user hasn't asked for calm/reduced motion.
+    // Safe on pages without a carousel and on live theme switches.
+    applyMotionPreference() {
+      if (!this.elements.carousel) return;
+      if (prefersCalm()) {
+        this.state.isAutoRotateEnabled = false;
+        this.stopAutoRotate();
+      } else {
+        this.state.isAutoRotateEnabled = true;
+        this.startAutoRotate();
+      }
     },
 
     cacheElements() {
@@ -635,6 +658,7 @@
     },
 
     fireMatrixTrail() {
+      if (prefersCalm()) return; // calm/reduced-motion: skip the rain, scroll still runs
       if (this.canvas) return; // already running
 
       var canvas = document.createElement("canvas");
@@ -764,6 +788,28 @@
   };
 
   // =============================================================================
+  // Theme toggle (calm / loud)
+  // =============================================================================
+  const Theme = {
+    init() {
+      const btn = utils.getElementById("theme-toggle");
+      if (!btn) return;
+      const isCalm = () => document.documentElement.dataset.theme === "calm";
+      btn.setAttribute("aria-pressed", String(isCalm()));
+      utils.addEventListenerSafe(btn, "click", () => {
+        const nowCalm = !isCalm();
+        document.documentElement.dataset.theme = nowCalm ? "calm" : "";
+        try {
+          localStorage.setItem("theme", nowCalm ? "calm" : "loud");
+        } catch (e) {}
+        btn.setAttribute("aria-pressed", String(nowCalm));
+        // Re-apply JS-driven motion policy live (carousel auto-rotate).
+        Carousel.applyMotionPreference();
+      });
+    },
+  };
+
+  // =============================================================================
   // Main Application
   // =============================================================================
   const App = {
@@ -777,6 +823,7 @@
       ScrollTop.init();
       FooterYear.init();
       LogoSliderLazy.init();
+      Theme.init();
     },
   };
 

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -15,9 +15,12 @@ module.exports = defineConfig({
     },
 
     webServer: {
-        // npx http-server . -p 8080 --silent
-        command: 'npx --yes http-server . -p 8080 --silent',
+        // Python's stdlib server (preinstalled on macOS/CI, ThreadingHTTPServer
+        // since 3.7) — same server the README documents for local dev. Avoids
+        // depending on `npx http-server` being fetchable/usable at run time.
+        command: 'python3 -m http.server 8080',
         url: 'http://localhost:8080',
+        stdout: 'ignore',
         // Reuse :8080 when already serving (avoids bind errors if CI=1 is set locally).
         // GitHub Actions always sets GITHUB_ACTIONS — there we always start a fresh server.
         reuseExistingServer: !process.env.GITHUB_ACTIONS,

--- a/raum-nutzen.html
+++ b/raum-nutzen.html
@@ -48,7 +48,11 @@
         <link rel="canonical" href="https://bitcircus101.de/raum-nutzen.html" />
 
         <link rel="icon" type="image/svg+xml" href="images/favicon.svg" />
-        <link rel="stylesheet" href="style.css?v=5" />
+        <script>
+            // No-flash: apply persisted calm theme before stylesheet paints.
+            try { if (localStorage.getItem("theme") === "calm") document.documentElement.dataset.theme = "calm"; } catch (e) {}
+        </script>
+        <link rel="stylesheet" href="style.css?v=6" />
 
         <!-- Structured Data -->
         <script type="application/ld+json">
@@ -98,6 +102,7 @@
                     <li><a href="donations.html" class="nav__cta">Unterstützen</a></li>
                     <li><a href="index.html#contact">Kontakt</a></li>
                     <li><a href="feed.xml" class="nav__rss" title="RSS Feed" aria-label="RSS-Feed der Termine">&#9673; RSS</a></li>
+                    <li><button type="button" class="theme-toggle" id="theme-toggle" aria-pressed="false" aria-label="Ruhiges Design umschalten" title="Ruhiges Design (calm)">calm</button></li>
                 </ul>
             </nav>
         </header>
@@ -273,6 +278,6 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX                   X                      
             </div>
         </footer>
 
-        <script defer src="main.js?v=7"></script>
+        <script defer src="main.js?v=8"></script>
     </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -320,6 +320,27 @@ nav li a.nav__cta.nav__link--current:focus-visible {
     color: var(--accent);
 }
 
+/* Calm/loud theme toggle — compact pill in the nav, styled like .nav__rss */
+.theme-toggle {
+    background: none;
+    border: 1px solid var(--border);
+    color: var(--text-dim);
+    font-family: var(--font);
+    font-size: 0.78rem;
+    letter-spacing: 0.04em;
+    line-height: 1;
+    padding: 0.3em 0.7em;
+    cursor: pointer;
+    transition: color var(--transition), border-color var(--transition);
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible,
+.theme-toggle[aria-pressed="true"] {
+    color: var(--accent);
+    border-color: var(--accent);
+}
+
 /* =============================================================================
    Buttons
    ============================================================================= */
@@ -2602,6 +2623,93 @@ h3.sr-only {
         --border: #ffffff;
         --text-dim: #cccccc;
     }
+}
+
+/* =============================================================================
+   Calm theme — opt-in via data-theme="calm"
+   Same override mechanism as the prefers-contrast block above: re-points the
+   existing tokens, collapses the off-accents onto one, freezes decorative
+   motion, dims the hero. Purely additive — :root stays untouched.
+   ============================================================================= */
+:root[data-theme="calm"] {
+    /* Lifted, lower-contrast surfaces — less black void, less neon */
+    --bg:            #14171a;
+    --bg-elevated:   #1b1f23;
+    --bg-panel:      #1f2429;
+    /* One desaturated teal collapses the green/pink/orange chorus */
+    --accent:        #5fb89a;
+    --accent-dim:    #4d9a80;
+    --border-accent: #5fb89a;
+    --text:          #c9cdd2;
+    --text-dim:      #8a9099;
+    --text-bright:   #eef1f4;
+    --border:        #313840;
+    /* Calmer rhythm: more air, no snappy 140ms flashes */
+    --line-height:   1.85;
+    --transition:    220ms ease;
+}
+
+/* Pull the loud off-accents (pink CTA, orange RSS) onto the single accent */
+[data-theme="calm"] nav li a.nav__cta { color: var(--accent); }
+[data-theme="calm"] nav li a.nav__cta:hover,
+[data-theme="calm"] nav li a.nav__cta:focus-visible { color: var(--text-bright); }
+[data-theme="calm"] nav li a.nav__cta.nav__link--current,
+[data-theme="calm"] nav li a.nav__cta.nav__link--current:hover,
+[data-theme="calm"] nav li a.nav__cta.nav__link--current:focus-visible {
+    box-shadow: inset 0 -2px 0 var(--accent);
+}
+
+[data-theme="calm"] .btn-primary {
+    background: transparent;
+    color: var(--accent);
+    border-color: var(--accent);
+}
+[data-theme="calm"] .btn-primary:hover {
+    background: var(--accent);
+    color: var(--bg);
+    border-color: var(--accent);
+}
+
+[data-theme="calm"] .nav__rss { color: var(--text-dim); border-color: var(--border); }
+[data-theme="calm"] .nav__rss:hover { color: var(--accent); border-color: var(--accent); }
+
+/* Kill decorative glow halos */
+[data-theme="calm"] .btn-shimmer,
+[data-theme="calm"] .btn-shimmer:hover,
+[data-theme="calm"] .location-card:hover,
+[data-theme="calm"] .location-card:focus-within,
+[data-theme="calm"] .chat-close,
+[data-theme="calm"] .signal-decode-btn { box-shadow: none; }
+
+/* Freeze blinking cursors and the glow pulse — visible, but still */
+[data-theme="calm"] .nav__cursor,
+[data-theme="calm"] .location-card__cursor,
+[data-theme="calm"] .events-cursor {
+    animation: none;
+    opacity: 1;
+}
+[data-theme="calm"] .signal-decode-btn { animation: none; }
+
+/* Marquee → static wrapped row (reuse of the reduced-motion fallback) */
+[data-theme="calm"] .logo-slider__track {
+    animation: none;
+    width: 100%;
+    max-width: 100%;
+    flex-wrap: wrap;
+    justify-content: center;
+    row-gap: var(--gap-md);
+}
+[data-theme="calm"] .logo-slider__viewport {
+    overflow: visible;
+    padding-block: var(--gap-lg);
+}
+[data-theme="calm"] .logo-slider__set[aria-hidden="true"] { display: none; }
+
+/* Hero ASCII steps back: smaller stage, dimmed, lower contrast */
+[data-theme="calm"] #home .ascii-art-viewport {
+    height: clamp(180px, 32vh, 300px);
+    background: var(--bg-elevated);
+    opacity: 0.82;
 }
 
 /* =============================================================================

--- a/style.css
+++ b/style.css
@@ -290,12 +290,6 @@ nav li a.nav__cta.nav__link--current {
     box-shadow: inset 0 -2px 0 #ff4da6;
 }
 
-nav li a.nav__link--current:hover,
-nav li a.nav__link--current:focus-visible {
-    color: var(--text-bright);
-    text-decoration: none;
-    box-shadow: inset 0 -2px 0 var(--accent);
-}
 nav li a.nav__cta.nav__link--current:hover,
 nav li a.nav__cta.nav__link--current:focus-visible {
     color: var(--text-bright);
@@ -386,11 +380,6 @@ nav li a.nav__cta.nav__link--current:focus-visible {
     color: var(--accent);
     border-color: var(--accent);
     box-shadow: 0 0 16px rgba(0, 217, 126, 0.4);
-}
-
-.btn-block {
-    width: 100%;
-    display: flex;
 }
 
 /* =============================================================================
@@ -548,7 +537,6 @@ nav li a.nav__cta.nav__link--current:focus-visible {
     }
     .footer__col--links {
         text-align: left;
-        grid-column: 1 / -1;
         gap: 1rem;
     }
     .footer__bar {
@@ -694,7 +682,6 @@ select:focus {
    Utilities
    ============================================================================= */
 .text-center { text-align: center; }
-.mt-lg { margin-top: var(--gap-lg); }
 .hidden { display: none !important; }
 
 /* =============================================================================
@@ -708,137 +695,6 @@ select:focus {
 .contact-info p { margin: var(--gap-sm) 0; }
 .contact-info a { color: var(--accent); font-weight: bold; }
 
-.signal-group { margin: var(--gap-lg) 0; text-align: center; }
-.signal-text {
-    margin-bottom: var(--gap-lg);
-    color: var(--text-dim);
-    font-size: 0.85rem;
-    letter-spacing: 0.03em;
-}
-
-.signal-channels {
-    display: flex;
-    gap: 2rem;
-    justify-content: center;
-    flex-wrap: wrap;
-    align-items: stretch;
-}
-
-/* Card – <a> is positioning anchor for ::after overlay */
-.signal-channel {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    text-decoration: none;
-    border: 1px solid var(--border);
-    padding: 1.5rem 1.75rem 1.25rem;
-    transition: border-color 0.2s ease;
-    min-width: 170px;
-}
-
-.signal-channel--primary {
-    border-color: var(--accent);
-}
-
-.signal-channel--red { border-color: rgba(255, 34, 34, 0.55); }
-.signal-channel--red .signal-channel-label { color: #ff2222; }
-.signal-channel--red:hover { border-color: #ff4444; }
-
-.signal-channel--blue { border-color: rgba(34, 102, 255, 0.55); }
-.signal-channel--blue .signal-channel-label { color: #2266ff; }
-.signal-channel--blue:hover { border-color: #4488ff; }
-
-.signal-channel:not(.signal-channel--primary):hover {
-    border-color: var(--accent-dim);
-}
-
-/* Inner wrapper gets dimmed on sibling hover */
-.signal-channel-inner {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0.9rem;
-    transition: opacity 0.25s ease;
-}
-
-/* Header row: label + badge side by side */
-.signal-channel-header {
-    display: flex;
-    align-items: center;
-    gap: 0.6rem;
-}
-
-.signal-channel-label {
-    font-size: 0.95rem;
-    color: var(--accent);
-    letter-spacing: 0.1em;
-}
-
-.signal-channel-badge {
-    font-size: 0.6rem;
-    letter-spacing: 0.12em;
-    padding: 0.15em 0.5em;
-    border: 1px solid var(--accent);
-    color: var(--accent);
-    line-height: 1.4;
-}
-
-.signal-channel-badge--dim {
-    border-color: var(--border);
-    color: var(--text-dim);
-}
-
-.signal-qr {
-    display: block;
-    width: 140px;
-    height: 140px;
-    max-width: 36vw;
-    max-height: 36vw;
-}
-
-.signal-channel-desc {
-    font-size: 0.75rem;
-    color: var(--text-dim);
-    letter-spacing: 0.02em;
-    line-height: 1.6;
-}
-
-/* Scan-hint overlay: on top of dimmed card, pointer-events off */
-.signal-channel::after {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    color: var(--accent);
-    font-family: var(--font);
-    font-size: 0.75rem;
-    white-space: nowrap;
-    pointer-events: none;
-    opacity: 0;
-    transition: opacity 0.25s ease;
-    border: 1px solid var(--accent);
-    padding: 0.35em 0.8em;
-    background: var(--bg);
-    letter-spacing: 0.06em;
-}
-
-.signal-channels:has(.signal-channel:first-child:hover) .signal-channel:last-child .signal-channel-inner {
-    opacity: 0.08;
-}
-.signal-channels:has(.signal-channel:first-child:hover) .signal-channel:last-child::after {
-    content: '← links scannen';
-    opacity: 1;
-}
-
-.signal-channels:has(.signal-channel:last-child:hover) .signal-channel:first-child .signal-channel-inner {
-    opacity: 0.08;
-}
-.signal-channels:has(.signal-channel:last-child:hover) .signal-channel:first-child::after {
-    content: 'rechts scannen →';
-    opacity: 1;
-}
-
 .signal-hint {
     font-size: 0.75rem;
     color: var(--text-dim);
@@ -850,17 +706,6 @@ select:focus {
 .signal-decode-block {
     margin: var(--gap-lg) 0;
     text-align: center;
-}
-
-.signal-decode-result {
-    display: inline-block;
-    font-size: 1.05rem;
-    font-weight: bold;
-    color: var(--accent);
-    letter-spacing: 0.22em;
-    min-width: 11rem;
-    text-align: center;
-    font-family: var(--font);
 }
 
 @keyframes signal-btn-glow {
@@ -889,44 +734,6 @@ select:focus {
 @media (prefers-reduced-motion: reduce) {
     .signal-decode-btn { animation: none; }
 }
-
-/* Chat page — ASCII art pills */
-.ascii-pills {
-    display: flex;
-    gap: var(--gap-xl);
-    justify-content: center;
-    flex-wrap: wrap;
-    margin: var(--gap-lg) 0;
-}
-
-.ascii-pill {
-    display: inline-block;
-    text-decoration: none;
-    transition: opacity var(--transition), filter var(--transition);
-    line-height: 1;
-}
-
-.ascii-pill:hover {
-    opacity: 0.7;
-    filter: brightness(1.4);
-    text-decoration: none;
-}
-
-.ascii-pill pre {
-    margin: 0;
-    padding: 0;
-    font-family: var(--font);
-    font-size: clamp(0.38rem, 1.4vw, 0.5rem);
-    line-height: 1.1;
-    white-space: pre;
-    overflow: visible;
-    background: none;
-    border: none;
-    color: inherit;
-}
-
-.ascii-pill--red  { color: #ff2222; }
-.ascii-pill--blue { color: #2266ff; }
 
 /* Chat page — minimal standalone */
 .chat-page {
@@ -991,56 +798,6 @@ select:focus {
 @media (prefers-reduced-motion: reduce) {
     .chat-page--closing { animation: none; opacity: 0; }
 }
-
-.chat-links {
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-xs);
-    margin-bottom: var(--gap-lg);
-    width: 100%;
-    max-width: 500px;
-}
-
-.chat-link {
-    display: flex;
-    align-items: center;
-    gap: var(--gap-sm);
-    padding: 0.45em 0.8em;
-    border: 1px solid var(--border);
-    text-decoration: none;
-    font-size: 0.72rem;
-    font-family: var(--font);
-    color: var(--text-dim);
-    background: var(--bg-elevated);
-    overflow: hidden;
-    transition: border-color var(--transition);
-}
-
-.chat-link:hover { text-decoration: none; }
-
-.chat-link__group {
-    flex-shrink: 0;
-    font-weight: bold;
-    letter-spacing: 0.06em;
-}
-
-.chat-link__url {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    opacity: 0.45;
-    font-size: 0.66rem;
-}
-
-.chat-link--red  { border-left: 2px solid #ff2222; }
-.chat-link--red  .chat-link__group { color: #ff2222; }
-.chat-link--red:hover  { border-color: rgba(255, 34, 34, 0.5); border-left-color: #ff2222; }
-.chat-link--red:hover  .chat-link__url { opacity: 0.75; }
-
-.chat-link--blue { border-left: 2px solid #2266ff; }
-.chat-link--blue .chat-link__group { color: #2266ff; }
-.chat-link--blue:hover { border-color: rgba(34, 102, 255, 0.5); border-left-color: #2266ff; }
-.chat-link--blue:hover .chat-link__url { opacity: 0.75; }
 
 /* Unified signal cards (chat page) */
 .chat-cards {
@@ -1160,11 +917,6 @@ select:focus {
 .chat-card--red:hover  { border-color: #ff4444; }
 .chat-card--blue { border-color: rgba(34, 102, 255, 0.5); color: #2266ff; }
 .chat-card--blue:hover { border-color: #4488ff; }
-
-.address {
-    margin: var(--gap-lg) 0;
-    line-height: var(--line-height);
-}
 
 /* =============================================================================
    Location Card
@@ -2077,19 +1829,6 @@ a.event-card__location:hover {
     }
 }
 
-.linkup-description {
-    margin: var(--gap-lg) 0;
-    padding: var(--gap-lg);
-    background: var(--bg-panel);
-    border-left: 2px solid var(--accent);
-}
-
-.linkup-description h3 {
-    margin-top: 0;
-    border-left: none;
-    padding-left: 0;
-}
-
 /* =============================================================================
    ASCII Art
    ============================================================================= */
@@ -2696,10 +2435,6 @@ h2.sr-only,
 h3.sr-only {
     border: none;
     padding: 0;
-}
-
-.signal-channel > h3.sr-only {
-    margin: 0;
 }
 
 .skip-link {

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -439,3 +439,52 @@ test.describe('Accessibility', () => {
         await expect(page.locator('[role="contentinfo"]')).toBeVisible();
     });
 });
+
+// ─── Calm Theme Toggle ───────────────────────────────────────────────────────
+
+test.describe('Calm theme toggle', () => {
+    test('toggles data-theme, persists across reload, applies calm tokens', async ({ page, context }) => {
+        const errors = [];
+        page.on('pageerror', (err) => errors.push(err.message));
+
+        // Desktop viewport so the nav toggle isn't inside the collapsed mobile menu
+        await page.setViewportSize({ width: 1280, height: 800 });
+        await context.clearCookies();
+        await page.goto('/');
+        await page.evaluate(() => { try { localStorage.removeItem('theme'); } catch (e) {} });
+        await page.reload();
+
+        const toggle = page.locator('#theme-toggle');
+        await expect(toggle).toBeVisible();
+        await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+        // Default (loud): green accent token
+        const accent = () => page.evaluate(() =>
+            getComputedStyle(document.documentElement).getPropertyValue('--accent').trim().toLowerCase()
+        );
+        expect(await accent()).toBe('#00d97e');
+
+        // Switch to calm: attribute, localStorage, aria-pressed all flip…
+        await toggle.click();
+        await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+        expect(await page.evaluate(() => document.documentElement.dataset.theme)).toBe('calm');
+        expect(await page.evaluate(() => localStorage.getItem('theme'))).toBe('calm');
+        // …and the calm token block is actually in effect (teal accent)
+        expect(await accent()).toBe('#5fb89a');
+
+        // Persists across reload without flashing back to loud (no-flash head script)
+        await page.reload();
+        expect(await page.evaluate(() => document.documentElement.dataset.theme)).toBe('calm');
+        await expect(page.locator('#theme-toggle')).toHaveAttribute('aria-pressed', 'true');
+        expect(await accent()).toBe('#5fb89a');
+
+        // Toggle back to loud
+        await page.locator('#theme-toggle').click();
+        await expect(page.locator('#theme-toggle')).toHaveAttribute('aria-pressed', 'false');
+        expect(await page.evaluate(() => localStorage.getItem('theme'))).toBe('loud');
+        expect(await page.evaluate(() => document.documentElement.dataset.theme || '')).toBe('');
+        expect(await accent()).toBe('#00d97e');
+
+        expect(errors).toEqual([]);
+    });
+});


### PR DESCRIPTION
Calm-theme feature branch: calm token overrides, nav toggle with no-flash head script, `prefersCalm()` motion gating, and the bare-domain event-URL normalization (`httpUrl`) plus tests.

Merged first so the stacked `fix/events-rss-correctness` PR diffs cleanly against main.