### PR TITLE
fix(events): calendar/RSS correctness + parser/aggregation refactor

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,16 +116,17 @@ jobs:
 
       - name: Minify CSS and JS
         run: |
-          echo "Before: style.css=$(wc -c < style.css)B main.js=$(wc -c < main.js)B events.js=$(wc -c < events.js)B"
+          echo "Before: style.css=$(wc -c < style.css)B main.js=$(wc -c < main.js)B events.js=$(wc -c < events.js)B ics-core.js=$(wc -c < ics-core.js)B"
           npx --yes csso-cli style.css -o style.css
           npx --yes terser main.js -o main.js --compress --mangle
           npx --yes terser events.js -o events.js --compress --mangle
-          echo "After:  style.css=$(wc -c < style.css)B main.js=$(wc -c < main.js)B events.js=$(wc -c < events.js)B"
+          npx --yes terser ics-core.js -o ics-core.js --compress --mangle
+          echo "After:  style.css=$(wc -c < style.css)B main.js=$(wc -c < main.js)B events.js=$(wc -c < events.js)B ics-core.js=$(wc -c < ics-core.js)B"
 
       - name: Cache-bust asset references
         run: |
           # Generate a short content hash from all cacheable assets (post-minification)
-          HASH=$(cat style.css main.js events.js 2>/dev/null | sha256sum | cut -c1-8)
+          HASH=$(cat style.css main.js events.js ics-core.js 2>/dev/null | sha256sum | cut -c1-8)
           echo "Asset hash: $HASH"
           # Replace ?v=anything with ?v=<hash> in all HTML files
           sed -i "s/?v=[a-zA-Z0-9_-]*/?v=$HASH/g" *.html

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,10 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Match the calendar's Europe/Berlin floating-local times when generating
+    # events-data.json / feed.xml and running the (date-sensitive) unit tests.
+    env:
+      TZ: Europe/Berlin
     steps:
       - uses: actions/checkout@v6
 
@@ -73,6 +77,9 @@ jobs:
   deploy:
     needs: test
     runs-on: ubuntu-latest
+    # Same TZ pin as the test job for the events-data.json regeneration fallback.
+    env:
+      TZ: Europe/Berlin
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/sync-events.yml
+++ b/.github/workflows/sync-events.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Use scripts and config from main
         run: |
           git fetch origin main
-          git checkout origin/main -- scripts/ calendars/
+          git checkout origin/main -- scripts/ calendars/ ics-core.js
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/sync-events.yml
+++ b/.github/workflows/sync-events.yml
@@ -15,6 +15,10 @@ concurrency:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    # ICS values from Nextcloud are floating-local Europe/Berlin; pin the runner TZ
+    # so date/time formatting (and UTC→local conversion) matches the calendar, not UTC.
+    env:
+      TZ: Europe/Berlin
     steps:
       - uses: actions/checkout@v6
         with:

--- a/events.html
+++ b/events.html
@@ -153,7 +153,8 @@
                 <span class="footer__status">lights: on</span>
             </div>
         </footer>
-        <script defer src="events.js?v=7"></script>
+        <script defer src="ics-core.js?v=8"></script>
+        <script defer src="events.js?v=8"></script>
         <script defer src="main.js?v=8"></script>
         <script>
             document.getElementById("linkup-info-btn").addEventListener("click", function() {

--- a/events.js
+++ b/events.js
@@ -131,7 +131,8 @@
         return new Date(e.date + "T23:59:59") >= now;
       })
       .sort(function (a, b) {
-        return new Date(a.date) - new Date(b.date);
+        // Date then time, so same-day events run chronologically (all-day first).
+        return (a.date + (a.time || "")).localeCompare(b.date + (b.time || ""));
       });
 
     onlyBitcircus = false;
@@ -315,7 +316,7 @@
           'data-href="#' + anchor + '" title="Link kopieren">' +
           '\u2190 link</button>';
         html += '<a class="event-action event-action--cal" href="' +
-          calHref +
+          esc(calHref) +
           '" target="_blank" rel="noopener" title="' + calTitle + '">' +
           calLabel + '</a>';
         if (e.location) {
@@ -343,6 +344,7 @@
         var href = btn.getAttribute("data-href");
         var url = window.location.origin + window.location.pathname + href;
         window.history.replaceState(null, "", href);
+        if (!navigator.clipboard || !navigator.clipboard.writeText) return;
         navigator.clipboard.writeText(url).then(function () {
           var orig = btn.innerHTML;
           btn.innerHTML = '<span class="event-action__icon">\u2713</span> kopiert';
@@ -351,6 +353,8 @@
             btn.innerHTML = orig;
             btn.classList.remove("event-action--copied");
           }, 1500);
+        }).catch(function () {
+          // Clipboard denied (e.g. non-secure context) \u2014 fail silently, URL is in the bar.
         });
       });
     });
@@ -426,6 +430,19 @@
           mo.setMonth(mo.getMonth() + 1);
         }
       }
+    } else if (p.FREQ === "DAILY") {
+      var interval = p.INTERVAL ? +p.INTERVAL : 1;
+      var cd = new Date(dtstart);
+      while (cd <= end && out.length < max) {
+        if (!exSet[cd.toDateString()]) out.push(new Date(cd));
+        cd.setDate(cd.getDate() + interval);
+      }
+    } else if (p.FREQ === "YEARLY") {
+      var cy = new Date(dtstart);
+      while (cy <= end && out.length < max) {
+        if (!exSet[cy.toDateString()]) out.push(new Date(cy));
+        cy.setFullYear(cy.getFullYear() + 1);
+      }
     }
     return out;
   }
@@ -491,23 +508,41 @@
     return events;
   }
 
+  // Mirror of guessType() in sync-events.mjs so the ICS fallback applies the same
+  // card styling as the generated JSON (the type drives the event-card--* border).
+  function guessType(summary) {
+    var s = (summary || "").toLowerCase();
+    if (s.indexOf("linkup") > -1) return "linkup";
+    if (s.indexOf("workshop") > -1 || s.indexOf("löten") > -1 ||
+        s.indexOf("hands-on") > -1) return "workshop";
+    return "special";
+  }
+
   function icsToCards(icsEvents) {
     var now = new Date();
+    var startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
     return icsEvents
-      .filter(function (e) { return e.dtstart > now; })
+      .filter(function (e) {
+        // All-day events (no time) stay until the day is over; timed events must be future.
+        return e.allDay ? e.dtstart >= startOfToday : e.dtstart > now;
+      })
       .sort(function (a, b) { return a.dtstart - b.dtstart; })
       .slice(0, 30)
       .map(function (e) {
+        // Local date components (not toISOString, which is UTC and would shift an
+        // all-day event's date by a day in non-UTC browsers).
+        var date = e.dtstart.getFullYear() + "-" +
+          pad(e.dtstart.getMonth() + 1) + "-" + pad(e.dtstart.getDate());
         return {
           title: e.summary,
           subtitle: "",
           description: e.description,
-          date: e.dtstart.toISOString().slice(0, 10),
+          date: date,
           time: e.allDay
             ? ""
             : pad(e.dtstart.getHours()) + ":" + pad(e.dtstart.getMinutes()),
           tags: [],
-          type: "regular",
+          type: guessType(e.summary),
         };
       });
   }

--- a/events.js
+++ b/events.js
@@ -20,7 +20,6 @@
     "JULI", "AUGUST", "SEPTEMBER", "OKTOBER", "NOVEMBER", "DEZEMBER",
   ];
   var DAYS = ["SO", "MO", "DI", "MI", "DO", "FR", "SA"];
-  var HORIZON = 120;
 
   // State
   var activeFilters = [];
@@ -253,10 +252,8 @@
       groupMap[k].forEach(function (e) {
         var d = new Date(e.date + "T00:00:00");
         var typeClass = e.type ? " event-card--" + e.type : "";
-        var slug = e.date + "-" + e.title.toLowerCase()
-          .replace(/[^a-z0-9\u00e4\u00f6\u00fc]+/g, "-")
-          .replace(/^-|-$/g, "").slice(0, 40);
-        var anchor = "ev-" + slug;
+        // Shared with the RSS feed's deep-link (ics-core.js) so anchors stay in sync.
+        var anchor = ICSCore.eventAnchor(e);
 
         html += '<article class="event-card' + typeClass +
           '" id="' + anchor + '">';
@@ -367,146 +364,8 @@
   }
 
   // ── ICS Parser (fallback) ─────────────────────────────────────────────────
-
-  function icsDate(v) {
-    if (!v) return null;
-    var y = +v.slice(0, 4), m = +v.slice(4, 6) - 1, d = +v.slice(6, 8);
-    if (v.length === 8) return new Date(y, m, d);
-    var h = +v.slice(9, 11), mi = +v.slice(11, 13);
-    return v.charAt(v.length - 1) === "Z"
-      ? new Date(Date.UTC(y, m, d, h, mi))
-      : new Date(y, m, d, h, mi);
-  }
-
-  function nthWeekday(year, month, wd, nth) {
-    var d = new Date(year, month, 1);
-    while (d.getDay() !== wd) d.setDate(d.getDate() + 1);
-    d.setDate(d.getDate() + (nth - 1) * 7);
-    return d.getMonth() === month ? d : null;
-  }
-
-  function expandRRule(dtstart, rule, exdates) {
-    var horizon = new Date();
-    horizon.setDate(horizon.getDate() + HORIZON);
-    var p = {};
-    rule.split(";").forEach(function (s) {
-      var i = s.indexOf("=");
-      if (i > -1) p[s.slice(0, i)] = s.slice(i + 1);
-    });
-    var WD = { SU: 0, MO: 1, TU: 2, WE: 3, TH: 4, FR: 5, SA: 6 };
-    var end = p.UNTIL ? icsDate(p.UNTIL) : null;
-    if (!end || end > horizon) end = horizon;
-    var max = p.COUNT ? +p.COUNT : 200;
-    var exSet = {};
-    exdates.forEach(function (d) { exSet[d.toDateString()] = true; });
-    var out = [];
-
-    if (p.FREQ === "WEEKLY") {
-      var wd = p.BYDAY
-        ? WD[p.BYDAY.replace(/\d/g, "").slice(-2)]
-        : dtstart.getDay();
-      if (wd === undefined) wd = dtstart.getDay();
-      var cur = new Date(dtstart);
-      while (cur.getDay() !== wd) cur.setDate(cur.getDate() + 1);
-      while (cur <= end && out.length < max) {
-        if (!exSet[cur.toDateString()]) out.push(new Date(cur));
-        cur.setDate(cur.getDate() + 7);
-      }
-    } else if (p.FREQ === "MONTHLY" && p.BYDAY) {
-      // Support both "3TH" (nth in BYDAY) and "TH" + BYSETPOS=3
-      var m = p.BYDAY.match(/^(\d+)([A-Z]{2})$/);
-      var nth = m ? +m[1] : (p.BYSETPOS ? +p.BYSETPOS : null);
-      var dayCode = m ? m[2] : p.BYDAY.replace(/\d/g, "").slice(-2);
-      var twd = WD[dayCode];
-      if (nth && twd != null) {
-        var mo = new Date(dtstart.getFullYear(), dtstart.getMonth(), 1);
-        while (mo <= end && out.length < max) {
-          var d = nthWeekday(mo.getFullYear(), mo.getMonth(), twd, nth);
-          if (d) {
-            d.setHours(dtstart.getHours(), dtstart.getMinutes(), 0, 0);
-            if (d >= dtstart && d <= end && !exSet[d.toDateString()])
-              out.push(new Date(d));
-          }
-          mo.setMonth(mo.getMonth() + 1);
-        }
-      }
-    } else if (p.FREQ === "DAILY") {
-      var interval = p.INTERVAL ? +p.INTERVAL : 1;
-      var cd = new Date(dtstart);
-      while (cd <= end && out.length < max) {
-        if (!exSet[cd.toDateString()]) out.push(new Date(cd));
-        cd.setDate(cd.getDate() + interval);
-      }
-    } else if (p.FREQ === "YEARLY") {
-      var cy = new Date(dtstart);
-      while (cy <= end && out.length < max) {
-        if (!exSet[cy.toDateString()]) out.push(new Date(cy));
-        cy.setFullYear(cy.getFullYear() + 1);
-      }
-    }
-    return out;
-  }
-
-  function cleanICS(s) {
-    return s.replace(/\\n/gi, " ").replace(/\\,/g, ",").replace(/\\;/g, ";").trim();
-  }
-
-  function parseICS(text) {
-    var lines = text.replace(/\r?\n[ \t]/g, "").split(/\r?\n/);
-    var events = [];
-    var ev = null;
-
-    for (var i = 0; i < lines.length; i++) {
-      var line = lines[i];
-      if (line === "BEGIN:VEVENT") { ev = { exdates: [] }; continue; }
-      if (line === "END:VEVENT") {
-        if (!ev || !ev.dtstart) { ev = null; continue; }
-        var dtstart = icsDate(ev.dtstart);
-        if (!dtstart) { ev = null; continue; }
-        var dtend = ev.dtend ? icsDate(ev.dtend) : null;
-        var allDay = !ev.dtstart.includes("T");
-        var base = {
-          summary: cleanICS(ev.summary || "(kein Titel)"),
-          description: cleanICS(ev.description || ""),
-          location: cleanICS(ev.location || ""),
-          allDay: allDay,
-        };
-        if (ev.rrule) {
-          var dur = dtend ? dtend - dtstart : 7200000;
-          expandRRule(dtstart, ev.rrule, ev.exdates).forEach(function (d) {
-            events.push({
-              summary: base.summary, description: base.description,
-              location: base.location, allDay: base.allDay,
-              dtstart: d, dtend: new Date(d.getTime() + dur),
-            });
-          });
-        } else {
-          base.dtstart = dtstart;
-          base.dtend = dtend;
-          events.push(base);
-        }
-        ev = null; continue;
-      }
-      if (!ev) continue;
-      var ci = line.indexOf(":");
-      if (ci === -1) continue;
-      var key = line.slice(0, ci).split(";")[0].toUpperCase();
-      var val = line.slice(ci + 1);
-      if (key === "DTSTART") ev.dtstart = val;
-      else if (key === "DTEND") ev.dtend = val;
-      else if (key === "SUMMARY") ev.summary = val;
-      else if (key === "DESCRIPTION") ev.description = val;
-      else if (key === "LOCATION") ev.location = val;
-      else if (key === "RRULE") ev.rrule = val;
-      else if (key === "EXDATE") {
-        val.split(",").forEach(function (v) {
-          var d = icsDate(v.trim());
-          if (d) ev.exdates.push(d);
-        });
-      }
-    }
-    return events;
-  }
+  // The parser itself lives in ics-core.js (window.ICSCore), shared with the Node
+  // sync script. This block only maps parsed events onto card objects.
 
   // Mirror of guessType() in sync-events.mjs so the ICS fallback applies the same
   // card styling as the generated JSON (the type drives the event-card--* border).
@@ -701,7 +560,7 @@
             return res.text();
           })
           .then(function (text) {
-            renderCards(icsToCards(parseICS(text)), el);
+            renderCards(icsToCards(ICSCore.parseICS(text)), el);
           })
           .catch(function () {
             renderError(el);

--- a/ics-core.js
+++ b/ics-core.js
@@ -1,0 +1,216 @@
+/**
+ * ics-core.js — shared ICS parser used by BOTH the Node sync script
+ * (scripts/sync-events.mjs) and the browser fallback (events.js).
+ *
+ * Single source of truth: edit the parser here and both consumers update. UMD
+ * wrapper exposes `module.exports` under Node (imported by the .mjs sync script)
+ * and a global `ICSCore` in the browser (loaded via <script> before events.js).
+ *
+ * Written in ES5 so the browser build needs no transpilation.
+ */
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) {
+    module.exports = factory();
+  } else {
+    root.ICSCore = factory();
+  }
+})(typeof self !== "undefined" ? self : this, function () {
+  "use strict";
+
+  var HORIZON_DAYS = 120;
+  var WD = { SU: 0, MO: 1, TU: 2, WE: 3, TH: 4, FR: 5, SA: 6 };
+
+  function parseDate(v) {
+    if (!v) return null;
+    var y = +v.slice(0, 4), m = +v.slice(4, 6) - 1, d = +v.slice(6, 8);
+    if (v.length === 8) return new Date(y, m, d);
+    var h = +v.slice(9, 11), mi = +v.slice(11, 13);
+    return v.charAt(v.length - 1) === "Z"
+      ? new Date(Date.UTC(y, m, d, h, mi))
+      : new Date(y, m, d, h, mi);
+  }
+
+  function nthWeekday(year, month, wd, nth) {
+    var d = new Date(year, month, 1);
+    while (d.getDay() !== wd) d.setDate(d.getDate() + 1);
+    d.setDate(d.getDate() + (nth - 1) * 7);
+    return d.getMonth() === month ? d : null;
+  }
+
+  function expandRRule(dtstart, rule, exdates) {
+    var horizon = new Date();
+    horizon.setDate(horizon.getDate() + HORIZON_DAYS);
+    var p = {};
+    rule.split(";").forEach(function (s) {
+      var i = s.indexOf("=");
+      if (i > -1) p[s.slice(0, i)] = s.slice(i + 1);
+    });
+    var end = p.UNTIL ? parseDate(p.UNTIL) : null;
+    var limit = end && end < horizon ? end : horizon;
+    var max = p.COUNT ? +p.COUNT : 200;
+    var exSet = {};
+    exdates.forEach(function (d) { exSet[d.toDateString()] = true; });
+    var out = [];
+
+    if (p.FREQ === "WEEKLY") {
+      var wd = p.BYDAY ? WD[p.BYDAY.replace(/\d/g, "").slice(-2)] : dtstart.getDay();
+      if (wd === undefined) wd = dtstart.getDay();
+      var cur = new Date(dtstart);
+      while (cur.getDay() !== wd) cur.setDate(cur.getDate() + 1);
+      while (cur <= limit && out.length < max) {
+        if (!exSet[cur.toDateString()]) out.push(new Date(cur));
+        cur.setDate(cur.getDate() + 7);
+      }
+    } else if (p.FREQ === "MONTHLY" && p.BYDAY) {
+      // Support both "3TH" (nth in BYDAY) and "TH" + BYSETPOS=3
+      var m = p.BYDAY.match(/^(\d+)([A-Z]{2})$/);
+      var nth = m ? +m[1] : (p.BYSETPOS ? +p.BYSETPOS : null);
+      var dayCode = m ? m[2] : p.BYDAY.replace(/\d/g, "").slice(-2);
+      var twd = WD[dayCode];
+      if (nth && twd != null) {
+        var mo = new Date(dtstart.getFullYear(), dtstart.getMonth(), 1);
+        while (mo <= limit && out.length < max) {
+          var d = nthWeekday(mo.getFullYear(), mo.getMonth(), twd, nth);
+          if (d) {
+            d.setHours(dtstart.getHours(), dtstart.getMinutes(), 0, 0);
+            if (d >= dtstart && d <= limit && !exSet[d.toDateString()]) out.push(new Date(d));
+          }
+          mo.setMonth(mo.getMonth() + 1);
+        }
+      }
+    } else if (p.FREQ === "DAILY") {
+      var interval = p.INTERVAL ? +p.INTERVAL : 1;
+      var cd = new Date(dtstart);
+      while (cd <= limit && out.length < max) {
+        if (!exSet[cd.toDateString()]) out.push(new Date(cd));
+        cd.setDate(cd.getDate() + interval);
+      }
+    } else if (p.FREQ === "YEARLY") {
+      var cy = new Date(dtstart);
+      while (cy <= limit && out.length < max) {
+        if (!exSet[cy.toDateString()]) out.push(new Date(cy));
+        cy.setFullYear(cy.getFullYear() + 1);
+      }
+    } else {
+      // MONTHLY-by-monthday, hourly, etc. are not expanded — surface it instead of
+      // silently dropping the event so a missing series is debuggable from CI logs.
+      console.warn("[rrule] unsupported FREQ=" + (p.FREQ || "?") + " — event not expanded");
+    }
+    return out;
+  }
+
+  function clean(s) {
+    return s.replace(/\\n/gi, " ").replace(/\\,/g, ",").replace(/\\;/g, ";").trim();
+  }
+
+  /** Pull TZID parameter out of a property like "DTSTART;TZID=Europe/Berlin" */
+  function parseTzid(rawKey) {
+    var m = rawKey.match(/TZID=([^;:]+)/i);
+    return m ? m[1] : null;
+  }
+
+  var tzidWarned = {};
+
+  /**
+   * Parse VEVENTs into a flat list. Extracts the full field superset
+   * (uid/url/categories/tzid); consumers ignore what they don't need.
+   * Recurring events are expanded into one entry per occurrence.
+   */
+  function parseICS(text, sourceId) {
+    sourceId = sourceId || "?";
+    var lines = text.replace(/\r?\n[ \t]/g, "").split(/\r?\n/);
+    var events = [];
+    var ev = null;
+
+    for (var li = 0; li < lines.length; li++) {
+      var line = lines[li];
+      if (line === "BEGIN:VEVENT") { ev = { exdates: [] }; continue; }
+      if (line === "END:VEVENT") {
+        if (!ev || !ev.dtstart) { ev = null; continue; }
+        var dtstart = parseDate(ev.dtstart);
+        if (!dtstart) { ev = null; continue; }
+        var dtend = ev.dtend ? parseDate(ev.dtend) : null;
+        var allDay = ev.dtstart.indexOf("T") === -1;
+        // Warn (once per source/zone) for foreign timezones — values stay floating local
+        if (ev.tzid && ev.tzid !== "Europe/Berlin" && ev.dtstart.charAt(ev.dtstart.length - 1) !== "Z") {
+          var wkey = sourceId + "|" + ev.tzid;
+          if (!tzidWarned[wkey]) {
+            tzidWarned[wkey] = true;
+            console.warn("[" + sourceId + "] non-Europe/Berlin TZID seen (" + ev.tzid + "); times treated as local");
+          }
+        }
+        var base = {
+          uid: ev.uid || "",
+          url: ev.url || "",
+          summary: clean(ev.summary || "(kein Titel)"),
+          description: clean(ev.description || ""),
+          location: clean(ev.location || ""),
+          categories: ev.categories || "",
+          allDay: allDay,
+        };
+        if (ev.rrule) {
+          var dur = dtend ? dtend - dtstart : 7200000;
+          expandRRule(dtstart, ev.rrule, ev.exdates).forEach(function (d) {
+            var inst = {};
+            for (var k in base) inst[k] = base[k];
+            inst.dtstart = d;
+            inst.dtend = new Date(d.getTime() + dur);
+            events.push(inst);
+          });
+        } else {
+          base.dtstart = dtstart;
+          base.dtend = dtend;
+          events.push(base);
+        }
+        ev = null; continue;
+      }
+      if (!ev) continue;
+      var ci = line.indexOf(":");
+      if (ci === -1) continue;
+      var rawKey = line.slice(0, ci);
+      var key = rawKey.split(";")[0].toUpperCase();
+      var val = line.slice(ci + 1);
+      if (key === "DTSTART") { ev.dtstart = val; ev.tzid = parseTzid(rawKey); }
+      else if (key === "DTEND") ev.dtend = val;
+      else if (key === "SUMMARY") ev.summary = val;
+      else if (key === "DESCRIPTION") ev.description = val;
+      else if (key === "LOCATION") ev.location = val;
+      else if (key === "CATEGORIES") ev.categories = val;
+      else if (key === "UID") ev.uid = val.trim();
+      else if (key === "URL") {
+        var u = val.trim();
+        ev.url = u && !/^https?:\/\//i.test(u) ? "https://" + u : u;
+      }
+      else if (key === "RRULE") ev.rrule = val;
+      else if (key === "EXDATE") {
+        val.split(",").forEach(function (v) {
+          var d = parseDate(v.trim());
+          if (d) ev.exdates.push(d);
+        });
+      }
+    }
+    return events;
+  }
+
+  /**
+   * Stable DOM-anchor / RSS-permalink id for an event card. Shared so the feed's
+   * <link> deep-links to exactly the anchor events.js renders (no slug drift).
+   */
+  function eventAnchor(card) {
+    var slug = card.date + "-" + (card.title || "").toLowerCase()
+      .replace(/[^a-z0-9äöü]+/g, "-")
+      .replace(/^-|-$/g, "").slice(0, 40);
+    return "ev-" + slug;
+  }
+
+  return {
+    HORIZON_DAYS: HORIZON_DAYS,
+    parseDate: parseDate,
+    nthWeekday: nthWeekday,
+    expandRRule: expandRRule,
+    clean: clean,
+    parseTzid: parseTzid,
+    parseICS: parseICS,
+    eventAnchor: eventAnchor,
+  };
+});

--- a/scripts/sync-events.mjs
+++ b/scripts/sync-events.mjs
@@ -6,9 +6,13 @@
  */
 
 const SITE_URL = "https://bitcircus101.de";
-const HORIZON_DAYS = 120;
 
 import { readFileSync, writeFileSync } from "node:fs";
+import ICSCore from "../ics-core.js";
+
+// ICS parsing primitives are shared with the browser fallback (events.js) via the
+// UMD module ics-core.js — single source of truth, no drift between the two parsers.
+const { parseDate, nthWeekday, expandRRule, clean, parseTzid, parseICS, eventAnchor } = ICSCore;
 
 const CAL_DIR = "calendars";
 const CAL_CONFIG = `${CAL_DIR}/config.json`;
@@ -39,164 +43,6 @@ function loadCalendars() {
     }
   }
   return loaded;
-}
-
-// ── ICS Parser ──────────────────────────────────────────────────────────────
-
-function parseDate(v) {
-  if (!v) return null;
-  const y = +v.slice(0, 4), m = +v.slice(4, 6) - 1, d = +v.slice(6, 8);
-  if (v.length === 8) return new Date(y, m, d);
-  const h = +v.slice(9, 11), mi = +v.slice(11, 13);
-  return v.endsWith("Z")
-    ? new Date(Date.UTC(y, m, d, h, mi))
-    : new Date(y, m, d, h, mi);
-}
-
-function nthWeekday(year, month, wd, nth) {
-  const d = new Date(year, month, 1);
-  while (d.getDay() !== wd) d.setDate(d.getDate() + 1);
-  d.setDate(d.getDate() + (nth - 1) * 7);
-  return d.getMonth() === month ? d : null;
-}
-
-function expandRRule(dtstart, rule, exdates) {
-  const horizon = new Date();
-  horizon.setDate(horizon.getDate() + HORIZON_DAYS);
-  const p = Object.fromEntries(
-    rule.split(";").map((s) => s.split("=")).filter((a) => a.length === 2)
-  );
-  const WD = { SU: 0, MO: 1, TU: 2, WE: 3, TH: 4, FR: 5, SA: 6 };
-  const end = p.UNTIL ? parseDate(p.UNTIL) : null;
-  const limit = end && end < horizon ? end : horizon;
-  const max = p.COUNT ? +p.COUNT : 200;
-  const exSet = new Set(exdates.map((d) => d.toDateString()));
-  const out = [];
-
-  if (p.FREQ === "WEEKLY") {
-    const wd = p.BYDAY
-      ? WD[p.BYDAY.replace(/\d/g, "").slice(-2)] ?? dtstart.getDay()
-      : dtstart.getDay();
-    const cur = new Date(dtstart);
-    while (cur.getDay() !== wd) cur.setDate(cur.getDate() + 1);
-    while (cur <= limit && out.length < max) {
-      if (!exSet.has(cur.toDateString())) out.push(new Date(cur));
-      cur.setDate(cur.getDate() + 7);
-    }
-  } else if (p.FREQ === "MONTHLY" && p.BYDAY) {
-    // Support both "3TH" (nth in BYDAY) and "TH" + BYSETPOS=3
-    const m = p.BYDAY.match(/^(\d+)([A-Z]{2})$/);
-    const nth = m ? +m[1] : (p.BYSETPOS ? +p.BYSETPOS : null);
-    const dayCode = m ? m[2] : p.BYDAY.replace(/\d/g, "").slice(-2);
-    const twd = WD[dayCode];
-    if (nth && twd != null) {
-      const mo = new Date(dtstart.getFullYear(), dtstart.getMonth(), 1);
-      while (mo <= limit && out.length < max) {
-        const d = nthWeekday(mo.getFullYear(), mo.getMonth(), twd, nth);
-        if (d) {
-          d.setHours(dtstart.getHours(), dtstart.getMinutes(), 0, 0);
-          if (d >= dtstart && d <= limit && !exSet.has(d.toDateString()))
-            out.push(new Date(d));
-        }
-        mo.setMonth(mo.getMonth() + 1);
-      }
-    }
-  } else if (p.FREQ === "DAILY") {
-    const interval = p.INTERVAL ? +p.INTERVAL : 1;
-    const cur = new Date(dtstart);
-    while (cur <= limit && out.length < max) {
-      if (!exSet.has(cur.toDateString())) out.push(new Date(cur));
-      cur.setDate(cur.getDate() + interval);
-    }
-  } else if (p.FREQ === "YEARLY") {
-    const cur = new Date(dtstart);
-    while (cur <= limit && out.length < max) {
-      if (!exSet.has(cur.toDateString())) out.push(new Date(cur));
-      cur.setFullYear(cur.getFullYear() + 1);
-    }
-  } else {
-    // MONTHLY-by-monthday, hourly, etc. are not expanded — surface it instead of
-    // silently dropping the event so a missing series is debuggable from CI logs.
-    console.warn(`[rrule] unsupported FREQ=${p.FREQ || "?"} — event not expanded`);
-  }
-  return out;
-}
-
-function clean(s) {
-  return s.replace(/\\n/gi, " ").replace(/\\,/g, ",").replace(/\\;/g, ";").trim();
-}
-
-/** Pull TZID parameter out of a property like "DTSTART;TZID=Europe/Berlin" */
-function parseTzid(rawKey) {
-  const m = rawKey.match(/TZID=([^;:]+)/i);
-  return m ? m[1] : null;
-}
-
-const tzidWarned = new Set();
-
-function parseICS(text, sourceId = "?") {
-  const lines = text.replace(/\r?\n[ \t]/g, "").split(/\r?\n/);
-  const events = [];
-  let ev = null;
-
-  for (const line of lines) {
-    if (line === "BEGIN:VEVENT") { ev = { exdates: [] }; continue; }
-    if (line === "END:VEVENT") {
-      if (!ev?.dtstart) { ev = null; continue; }
-      const dtstart = parseDate(ev.dtstart);
-      if (!dtstart) { ev = null; continue; }
-      const dtend = ev.dtend ? parseDate(ev.dtend) : null;
-      const allDay = !ev.dtstart.includes("T");
-      // Warn (once per source/zone) for foreign timezones — values stay as floating local
-      if (ev.tzid && ev.tzid !== "Europe/Berlin" && !ev.dtstart.endsWith("Z")) {
-        const key = `${sourceId}|${ev.tzid}`;
-        if (!tzidWarned.has(key)) {
-          tzidWarned.add(key);
-          console.warn(`[${sourceId}] non-Europe/Berlin TZID seen (${ev.tzid}); times treated as local`);
-        }
-      }
-      const base = {
-        uid: ev.uid || "",
-        url: ev.url || "",
-        summary: clean(ev.summary || "(kein Titel)"),
-        description: clean(ev.description || ""),
-        location: clean(ev.location || ""),
-        categories: ev.categories || "",
-        allDay,
-      };
-      if (ev.rrule) {
-        const dur = dtend ? dtend - dtstart : 7200000;
-        for (const d of expandRRule(dtstart, ev.rrule, ev.exdates)) {
-          events.push({ ...base, dtstart: d, dtend: new Date(d.getTime() + dur) });
-        }
-      } else {
-        events.push({ ...base, dtstart, dtend });
-      }
-      ev = null; continue;
-    }
-    if (!ev) continue;
-    const ci = line.indexOf(":");
-    if (ci === -1) continue;
-    const rawKey = line.slice(0, ci);
-    const key = rawKey.split(";")[0].toUpperCase();
-    const val = line.slice(ci + 1);
-    if (key === "DTSTART") { ev.dtstart = val; ev.tzid = parseTzid(rawKey); }
-    else if (key === "DTEND") ev.dtend = val;
-    else if (key === "SUMMARY") ev.summary = val;
-    else if (key === "DESCRIPTION") ev.description = val;
-    else if (key === "LOCATION") ev.location = val;
-    else if (key === "CATEGORIES") ev.categories = val;
-    else if (key === "UID") ev.uid = val.trim();
-    else if (key === "URL") { const u = val.trim(); ev.url = u && !/^https?:\/\//i.test(u) ? `https://${u}` : u; }
-    else if (key === "RRULE") ev.rrule = val;
-    else if (key === "EXDATE") {
-      for (const v of val.split(",")) {
-        const d = parseDate(v.trim());
-        if (d) ev.exdates.push(d);
-      }
-    }
-  }
-  return events;
 }
 
 // ── Transform to card format ────────────────────────────────────────────────
@@ -402,7 +248,7 @@ function generateRSS(cards) {
     xml += `
     <item>
       <title>${escXml(fullTitle)}</title>
-      <link>${SITE_URL}/events.html</link>
+      <link>${SITE_URL}/events.html#${eventAnchor(c)}</link>
       <description>${escXml(c.description || c.title + " · " + c.date)}</description>`;
     for (const tag of tags) {
       xml += `
@@ -437,94 +283,109 @@ function loadPrevious() {
   }
 }
 
-async function main() {
-  const calendars = loadCalendars();
-  const prev = loadPrevious();
-  let allCards = [];
-  const sources = [];
-  const newIcsKeys = {};
+const FETCH_TIMEOUT_MS = 15000;
 
-  for (const cal of calendars) {
-    console.log(`[${cal.id}] Fetching ${cal.ics}`);
-    const prevSource = prev.sources.find((s) => s.id === cal.id);
+/** fetch() with an abort timeout so one hanging source can't stall the whole sync. */
+function fetchWithTimeout(url, ms = FETCH_TIMEOUT_MS) {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), ms);
+  return fetch(url, { signal: ctrl.signal }).finally(() => clearTimeout(t));
+}
 
-    try {
-      const res = await fetch(cal.ics);
-      if (!res.ok) {
-        const reason = `HTTP ${res.status}`;
-        console.error(`[${cal.id}] ${reason} – using cached events`);
-        // Keep previous events alive, mark source as degraded
-        const cached = prev.events.filter((e) => e.source === cal.name);
-        allCards = allCards.concat(cached);
-        sources.push({
-          id: cal.id, name: cal.name,
-          fetchedAt: prevSource?.fetchedAt || null,
-          status: "stale", error: reason,
-          events: cached.length, added: 0, removed: 0,
-        });
-        continue;
-      }
-      const fetchedAt = new Date().toISOString();
-      const text = await res.text();
-      console.log(`[${cal.id}] ${text.length} bytes`);
-
-      let icsEvents = parseICS(text, cal.id);
-      console.log(`[${cal.id}] ${icsEvents.length} VEVENT entries`);
-
-      if (cal.filter) {
-        const before = icsEvents.length;
-        icsEvents = applyFilter(icsEvents, cal.filter);
-        console.log(`[${cal.id}] filter: ${before} → ${icsEvents.length}`);
-      }
-
-      const cards = toCards(icsEvents, cal);
-      console.log(`[${cal.id}] ${cards.length} upcoming cards`);
-      allCards = allCards.concat(cards);
-
-      // Diff against previous sync — prefer UID (stable), fall back to date|summary
-      // so natural event expiry doesn't count as a "removed" change.
-      const keyOf = (e) => e.uid || (e.dtstart.toISOString().slice(0, 10) + "|" + e.summary);
-      const now = new Date().toISOString().slice(0, 10);
-      const allIcsKeys = new Set(icsEvents.map(keyOf));
-      const prevIcsKeys = new Set(prev.icsKeys[cal.name] || []);
-      const added = [...allIcsKeys].filter((k) => !prevIcsKeys.has(k)).length;
-      // Only count upcoming events as "removed". A past event ageing out of the ICS
-      // export window is natural expiry, not a real change. Bare-UID keys carry no
-      // date part and keep the old behaviour (can't be dated).
-      const removed = [...prevIcsKeys].filter(
-        (k) => !allIcsKeys.has(k) && (!k.includes("|") || k.split("|")[0] >= now)
-      ).length;
-      newIcsKeys[cal.name] = [...allIcsKeys];
-
-      // Count past vs upcoming in full calendar
-      let past = 0, upcoming = 0;
-      for (const k of allIcsKeys) {
-        if (k.split("|")[0] >= now) upcoming++; else past++;
-      }
-
-      sources.push({
-        id: cal.id, name: cal.name, fetchedAt, status: "ok",
-        events: cards.length, added, removed,
-        total: allIcsKeys.size, past, upcoming,
-      });
-    } catch (err) {
-      const reason = err.message;
-      console.error(`[${cal.id}] Error: ${reason} – using cached events`);
-      // Keep previous events alive
-      const cached = prev.events.filter((e) => e.source === cal.name);
-      allCards = allCards.concat(cached);
-      sources.push({
+/**
+ * Fetch + parse + filter + diff a single source. Always resolves (never rejects):
+ * on any failure it returns the previous run's cached cards with status "stale", so
+ * one dead source never takes the others down. Returns a uniform shape consumed by
+ * aggregate(): { cards, source (meta), icsKeys ({name: [...]} | null) }.
+ */
+async function processSource(cal, prev) {
+  console.log(`[${cal.id}] Fetching ${cal.ics}`);
+  const prevSource = prev.sources.find((s) => s.id === cal.id);
+  const stale = (reason) => {
+    console.error(`[${cal.id}] ${reason} – using cached events`);
+    const cached = prev.events.filter((e) => e.source === cal.name);
+    return {
+      cards: cached,
+      source: {
         id: cal.id, name: cal.name,
         fetchedAt: prevSource?.fetchedAt || null,
         status: "stale", error: reason,
         events: cached.length, added: 0, removed: 0,
-      });
+      },
+      icsKeys: null,
+    };
+  };
+
+  try {
+    const res = await fetchWithTimeout(cal.ics);
+    if (!res.ok) return stale(`HTTP ${res.status}`);
+
+    const fetchedAt = new Date().toISOString();
+    const text = await res.text();
+    console.log(`[${cal.id}] ${text.length} bytes`);
+
+    let icsEvents = parseICS(text, cal.id);
+    console.log(`[${cal.id}] ${icsEvents.length} VEVENT entries`);
+
+    if (cal.filter) {
+      const before = icsEvents.length;
+      icsEvents = applyFilter(icsEvents, cal.filter);
+      console.log(`[${cal.id}] filter: ${before} → ${icsEvents.length}`);
     }
+
+    const cards = toCards(icsEvents, cal);
+    console.log(`[${cal.id}] ${cards.length} upcoming cards`);
+
+    // Diff against previous sync — prefer UID (stable), fall back to date|summary
+    // so natural event expiry doesn't count as a "removed" change.
+    const keyOf = (e) => e.uid || (e.dtstart.toISOString().slice(0, 10) + "|" + e.summary);
+    const today = new Date().toISOString().slice(0, 10);
+    const allIcsKeys = new Set(icsEvents.map(keyOf));
+    const prevIcsKeys = new Set(prev.icsKeys[cal.name] || []);
+    const added = [...allIcsKeys].filter((k) => !prevIcsKeys.has(k)).length;
+    // Only count upcoming events as "removed". A past event ageing out of the ICS
+    // export window is natural expiry, not a real change. Bare-UID keys carry no
+    // date part and keep the old behaviour (can't be dated).
+    const removed = [...prevIcsKeys].filter(
+      (k) => !allIcsKeys.has(k) && (!k.includes("|") || k.split("|")[0] >= today)
+    ).length;
+
+    let past = 0, upcoming = 0;
+    for (const k of allIcsKeys) {
+      if (k.split("|")[0] >= today) upcoming++; else past++;
+    }
+
+    return {
+      cards,
+      source: {
+        id: cal.id, name: cal.name, fetchedAt, status: "ok",
+        events: cards.length, added, removed,
+        total: allIcsKeys.size, past, upcoming,
+      },
+      icsKeys: { [cal.name]: [...allIcsKeys] },
+    };
+  } catch (err) {
+    return stale(err.name === "AbortError" ? `timeout after ${FETCH_TIMEOUT_MS}ms` : err.message);
+  }
+}
+
+/**
+ * Pure aggregation step — merges per-source results into the final output. No I/O,
+ * so it is unit-testable. `results` preserves manifest order, which drives dedupe
+ * priority (earlier source wins). `nowISO` is injected for deterministic firstSeen.
+ */
+function aggregate(results, prev, nowISO) {
+  let allCards = [];
+  const sources = [];
+  const icsKeys = {};
+  for (const r of results) {
+    allCards = allCards.concat(r.cards);
+    sources.push(r.source);
+    if (r.icsKeys) Object.assign(icsKeys, r.icsKeys);
   }
 
-  // Carry over firstSeen from previous sync, set to now for new events.
-  // Prefer UID lookup (stable across title edits), fall back to date|title for migration
-  // from pre-UID events-data.json — first run after rollout still picks up old entries.
+  // Carry over firstSeen from previous sync, set to now for new events. Prefer UID
+  // (stable across title edits), fall back to date|title for pre-UID migration.
   const prevByUid = {};
   const prevByDateTitle = {};
   for (const e of prev.events) {
@@ -532,7 +393,6 @@ async function main() {
     if (e.uid) prevByUid[e.uid] = e.firstSeen;
     prevByDateTitle[e.date + "|" + e.title] = e.firstSeen;
   }
-  const nowISO = new Date().toISOString();
   for (const c of allCards) {
     c.firstSeen = (c.uid && prevByUid[c.uid])
       || prevByDateTitle[c.date + "|" + c.title]
@@ -541,8 +401,7 @@ async function main() {
 
   // Dedupe across sources: the same event cross-posted to two calendars should appear
   // once. Key on UID-or-title PLUS the date+time slot so recurring instances (shared
-  // UID, different slot) are NOT collapsed. First occurrence wins → source order in
-  // the manifest acts as priority (bitcircus before datenburg before external).
+  // UID, different slot) are NOT collapsed. First occurrence wins.
   const seenCards = new Set();
   allCards = allCards.filter((c) => {
     const k = (c.uid || c.title.toLowerCase()) + "|" + c.date + "|" + (c.time || "");
@@ -556,19 +415,32 @@ async function main() {
     (a.date + (a.time || "")).localeCompare(b.date + (b.time || ""))
   );
   allCards = allCards.slice(0, 40);
-  console.log(`Total: ${allCards.length} event cards from ${calendars.length} calendars`);
 
-  // Update source event counts to reflect what actually made it into the output
+  // Reflect what actually made it into the output (after dedupe + cap).
   for (const s of sources) {
     s.events = allCards.filter((c) => c.source === s.name).length;
   }
 
-  const output = { lastSync: new Date().toISOString(), sources, icsKeys: newIcsKeys, events: allCards };
+  return { events: allCards, sources, icsKeys };
+}
+
+async function main() {
+  const calendars = loadCalendars();
+  const prev = loadPrevious();
+
+  // Fetch every source concurrently; Promise.all preserves array order so the
+  // manifest order still drives dedupe priority in aggregate().
+  const results = await Promise.all(calendars.map((cal) => processSource(cal, prev)));
+
+  const { events, sources, icsKeys } = aggregate(results, prev, new Date().toISOString());
+  console.log(`Total: ${events.length} event cards from ${calendars.length} calendars`);
+
+  const output = { lastSync: new Date().toISOString(), sources, icsKeys, events };
   writeFileSync("events-data.json", JSON.stringify(output, null, 2) + "\n");
   console.log("Written events-data.json");
 
-  // RSS only from primary calendar
-  const primaryCards = allCards.filter((c) =>
+  // RSS only from calendars flagged rss:true (the primary feed).
+  const primaryCards = events.filter((c) =>
     calendars.find((cal) => cal.name === c.source && cal.rss)
   );
   const rss = generateRSS(primaryCards);
@@ -590,4 +462,5 @@ export {
   isInternal, applyFilter, guessType, extractHashtags, keywordTags,
   buildTags, cleanLocation, truncateDesc, toCards,
   escXml, toRFC822, generateRSS,
+  aggregate, eventAnchor,
 };

--- a/scripts/sync-events.mjs
+++ b/scripts/sync-events.mjs
@@ -101,6 +101,23 @@ function expandRRule(dtstart, rule, exdates) {
         mo.setMonth(mo.getMonth() + 1);
       }
     }
+  } else if (p.FREQ === "DAILY") {
+    const interval = p.INTERVAL ? +p.INTERVAL : 1;
+    const cur = new Date(dtstart);
+    while (cur <= limit && out.length < max) {
+      if (!exSet.has(cur.toDateString())) out.push(new Date(cur));
+      cur.setDate(cur.getDate() + interval);
+    }
+  } else if (p.FREQ === "YEARLY") {
+    const cur = new Date(dtstart);
+    while (cur <= limit && out.length < max) {
+      if (!exSet.has(cur.toDateString())) out.push(new Date(cur));
+      cur.setFullYear(cur.getFullYear() + 1);
+    }
+  } else {
+    // MONTHLY-by-monthday, hourly, etc. are not expanded — surface it instead of
+    // silently dropping the event so a missing series is debuggable from CI logs.
+    console.warn(`[rrule] unsupported FREQ=${p.FREQ || "?"} — event not expanded`);
   }
   return out;
 }
@@ -313,12 +330,16 @@ function truncateDesc(s, max = 200) {
 
 function toCards(icsEvents, cal) {
   const now = new Date();
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   const cap = Number.isFinite(cal.cap) ? cal.cap : 30;
   // External calendars (ics-single, ics-filtered) link directly to event/program pages;
   // built-in Nextcloud sources use the timeGridDay day view, so we keep eventUrl unset.
   const isExternal = cal.type === "ics-filtered" || cal.type === "ics-single";
   return icsEvents
-    .filter((e) => e.dtstart > now && !isInternal(e.summary))
+    // All-day events carry no time (midnight). Comparing them against `now` would
+    // drop an all-day event happening *today* at any moment past 00:00, so gate them
+    // on the start of today instead; timed events keep the strict "future" check.
+    .filter((e) => (e.allDay ? e.dtstart >= startOfToday : e.dtstart > now) && !isInternal(e.summary))
     .sort((a, b) => a.dtstart - b.dtstart)
     .slice(0, cap)
     .map((e) => {
@@ -366,7 +387,11 @@ function generateRSS(cards) {
 `;
 
   for (const c of cards.slice(0, 15)) {
-    const guid = c.uid || `bitcircus101-${c.date.replace(/-/g, "")}-${c.type}`;
+    // Recurring events share a single UID across every instance. Append the
+    // occurrence's date+time slot so each item gets a unique GUID — otherwise feed
+    // readers dedupe on GUID and collapse the whole series into one entry.
+    const slot = c.date.replace(/-/g, "") + (c.time ? "T" + c.time.replace(":", "") : "");
+    const guid = c.uid ? `${c.uid}-${slot}` : `bitcircus101-${slot}-${c.type}`;
     const datePart = c.time ? `${c.date} ${c.time}` : c.date;
     const titleParts = [`[${datePart}] ${c.title}`];
     if (c.location) titleParts.push(`@ ${c.location}`);
@@ -385,7 +410,7 @@ function generateRSS(cards) {
     }
     xml += `
       <pubDate>${toRFC822(c.firstSeen || new Date().toISOString())}</pubDate>
-      <guid isPermaLink="false">${guid}</guid>
+      <guid isPermaLink="false">${escXml(guid)}</guid>
     </item>`;
   }
 
@@ -463,7 +488,12 @@ async function main() {
       const allIcsKeys = new Set(icsEvents.map(keyOf));
       const prevIcsKeys = new Set(prev.icsKeys[cal.name] || []);
       const added = [...allIcsKeys].filter((k) => !prevIcsKeys.has(k)).length;
-      const removed = [...prevIcsKeys].filter((k) => !allIcsKeys.has(k)).length;
+      // Only count upcoming events as "removed". A past event ageing out of the ICS
+      // export window is natural expiry, not a real change. Bare-UID keys carry no
+      // date part and keep the old behaviour (can't be dated).
+      const removed = [...prevIcsKeys].filter(
+        (k) => !allIcsKeys.has(k) && (!k.includes("|") || k.split("|")[0] >= now)
+      ).length;
       newIcsKeys[cal.name] = [...allIcsKeys];
 
       // Count past vs upcoming in full calendar
@@ -509,8 +539,22 @@ async function main() {
       || nowISO;
   }
 
-  // Sort all cards by date, limit to 40
-  allCards.sort((a, b) => a.date.localeCompare(b.date));
+  // Dedupe across sources: the same event cross-posted to two calendars should appear
+  // once. Key on UID-or-title PLUS the date+time slot so recurring instances (shared
+  // UID, different slot) are NOT collapsed. First occurrence wins → source order in
+  // the manifest acts as priority (bitcircus before datenburg before external).
+  const seenCards = new Set();
+  allCards = allCards.filter((c) => {
+    const k = (c.uid || c.title.toLowerCase()) + "|" + c.date + "|" + (c.time || "");
+    if (seenCards.has(k)) return false;
+    seenCards.add(k);
+    return true;
+  });
+
+  // Sort by date then time so same-day events run chronologically (all-day first).
+  allCards.sort((a, b) =>
+    (a.date + (a.time || "")).localeCompare(b.date + (b.time || ""))
+  );
   allCards = allCards.slice(0, 40);
   console.log(`Total: ${allCards.length} event cards from ${calendars.length} calendars`);
 

--- a/tests/sync-events.spec.mjs
+++ b/tests/sync-events.spec.mjs
@@ -12,6 +12,7 @@ import {
   parseDate, nthWeekday, expandRRule, clean, parseICS,
   applyFilter, buildTags, toCards,
   escXml, toRFC822, generateRSS,
+  aggregate, eventAnchor,
 } from "../scripts/sync-events.mjs";
 
 // ── parseDate ─────────────────────────────────────────────────────────────
@@ -622,5 +623,118 @@ describe("generateRSS", () => {
     assert.match(xml, /<guid isPermaLink="false">a&amp;b&lt;c-20260321T2000<\/guid>/);
     // no raw, unescaped ampersand anywhere in the feed
     assert.ok(!/&(?!amp;|lt;|gt;|quot;|#)/.test(xml));
+  });
+
+  it("deep-links the item to the event anchor", () => {
+    const xml = generateRSS([baseCard]);
+    assert.ok(
+      xml.includes("<link>https://bitcircus101.de/events.html#" + eventAnchor(baseCard) + "</link>")
+    );
+  });
+
+  it("stays well-formed XML with hostile field content", () => {
+    const nasty = {
+      ...baseCard,
+      title: 'A & B <x> "q"',
+      description: "<b>&amp;</b>",
+      location: "M&Ms <i>",
+      tags: ["<bad>&"],
+      uid: "u&<id",
+    };
+    const xml = generateRSS([nasty]);
+    assert.ok(!/&(?!amp;|lt;|gt;|quot;|#)/.test(xml), "no unescaped ampersand");
+    for (const tag of ["item", "title", "link", "description", "guid", "pubDate"]) {
+      const open = (xml.match(new RegExp("<" + tag + "[ >]", "g")) || []).length;
+      const close = (xml.match(new RegExp("</" + tag + ">", "g")) || []).length;
+      assert.equal(open, close, tag + " tags balanced");
+    }
+  });
+});
+
+// ── eventAnchor (shared deep-link slug) ───────────────────────────────────────
+
+describe("eventAnchor", () => {
+  it("builds a stable ev- anchor from date + title", () => {
+    assert.equal(
+      eventAnchor({ date: "2026-05-22", title: "Casual Linkup@bitcircus101 (4FR)" }),
+      "ev-2026-05-22-casual-linkup-bitcircus101-4fr"
+    );
+  });
+
+  it("keeps German umlauts and trims trailing separators", () => {
+    assert.equal(
+      eventAnchor({ date: "2026-06-01", title: "Löten für Anfänger!!!" }),
+      "ev-2026-06-01-löten-für-anfänger"
+    );
+  });
+});
+
+// ── aggregate (cross-source merge) ────────────────────────────────────────────
+
+describe("aggregate", () => {
+  const NOW = "2026-04-01T00:00:00.000Z";
+  const emptyPrev = { events: [], sources: [], icsKeys: {} };
+  const card = (over) => ({
+    title: "E", date: "2026-05-01", time: "20:00", uid: "",
+    source: "A", tags: [], type: "special", ...over,
+  });
+  const result = (cards, name) => ({
+    cards,
+    source: { id: name, name, status: "ok", events: cards.length },
+    icsKeys: { [name]: [] },
+  });
+
+  it("dedupes the same event cross-posted to two sources (first wins)", () => {
+    const a = result([card({ uid: "shared@x", source: "A" })], "A");
+    const b = result([card({ uid: "shared@x", source: "B" })], "B");
+    const { events } = aggregate([a, b], emptyPrev, NOW);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].source, "A");
+  });
+
+  it("keeps recurring instances (same uid, different date slot)", () => {
+    const a = result([
+      card({ uid: "weekly@x", date: "2026-05-01" }),
+      card({ uid: "weekly@x", date: "2026-05-08" }),
+    ], "A");
+    const { events } = aggregate([a], emptyPrev, NOW);
+    assert.equal(events.length, 2);
+  });
+
+  it("sorts same-day events by time, all-day first", () => {
+    const a = result([
+      card({ uid: "u1", time: "22:00", title: "late" }),
+      card({ uid: "u2", time: "", title: "allday" }),
+      card({ uid: "u3", time: "18:00", title: "early" }),
+    ], "A");
+    const { events } = aggregate([a], emptyPrev, NOW);
+    assert.deepEqual(events.map((e) => e.title), ["allday", "early", "late"]);
+  });
+
+  it("caps the merged output at 40 cards", () => {
+    const cards = Array.from({ length: 50 }, (_, i) =>
+      card({ uid: "u" + i, date: "2026-05-" + String((i % 28) + 1).padStart(2, "0") })
+    );
+    const { events } = aggregate([result(cards, "A")], emptyPrev, NOW);
+    assert.equal(events.length, 40);
+  });
+
+  it("carries firstSeen over by uid and defaults new events to nowISO", () => {
+    const prev = {
+      events: [{ uid: "old@x", date: "2026-05-01", title: "E", firstSeen: "2026-01-01T00:00:00.000Z" }],
+      sources: [], icsKeys: {},
+    };
+    const a = result([card({ uid: "old@x" }), card({ uid: "new@x", date: "2026-05-02" })], "A");
+    const { events } = aggregate([a], prev, NOW);
+    const seen = Object.fromEntries(events.map((e) => [e.uid, e.firstSeen]));
+    assert.equal(seen["old@x"], "2026-01-01T00:00:00.000Z");
+    assert.equal(seen["new@x"], NOW);
+  });
+
+  it("recomputes source.events to reflect the deduped output", () => {
+    const a = result([card({ uid: "shared@x", source: "A" })], "A");
+    const b = result([card({ uid: "shared@x", source: "B" })], "B");
+    const { sources } = aggregate([a, b], emptyPrev, NOW);
+    assert.equal(sources.find((s) => s.name === "B").events, 0);
   });
 });

--- a/tests/sync-events.spec.mjs
+++ b/tests/sync-events.spec.mjs
@@ -122,6 +122,46 @@ describe("expandRRule — WEEKLY", () => {
   });
 });
 
+describe("expandRRule — DAILY / YEARLY / unsupported", () => {
+  it("expands daily recurrence one day apart", () => {
+    const dtstart = new Date(2026, 2, 2, 19, 0);
+    const dates = expandRRule(dtstart, "FREQ=DAILY", []);
+    assert(dates.length > 1);
+    const diff = Math.round((dates[1] - dates[0]) / 86400000);
+    assert.equal(diff, 1);
+  });
+
+  it("honours DAILY INTERVAL", () => {
+    const dtstart = new Date(2026, 2, 2, 19, 0);
+    const dates = expandRRule(dtstart, "FREQ=DAILY;INTERVAL=3", []);
+    assert(dates.length > 1);
+    const diff = Math.round((dates[1] - dates[0]) / 86400000);
+    assert.equal(diff, 3);
+  });
+
+  it("expands yearly recurrence keeping month/day", () => {
+    const dtstart = new Date(2026, 2, 2, 19, 0);
+    const dates = expandRRule(dtstart, "FREQ=YEARLY", []);
+    assert(dates.length >= 1);
+    assert.equal(dates[0].getMonth(), 2);
+    assert.equal(dates[0].getDate(), 2);
+  });
+
+  it("warns once on an unsupported FREQ instead of silently dropping", () => {
+    const origWarn = console.warn;
+    const warnings = [];
+    console.warn = (m) => warnings.push(m);
+    try {
+      const dates = expandRRule(new Date(2026, 2, 2, 19, 0), "FREQ=HOURLY", []);
+      assert.equal(dates.length, 0);
+    } finally {
+      console.warn = origWarn;
+    }
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /unsupported FREQ=HOURLY/);
+  });
+});
+
 // ── parseICS ──────────────────────────────────────────────────────────────
 
 describe("parseICS", () => {
@@ -457,6 +497,22 @@ describe("toCards", () => {
     const r = toCards(events, { name: "X", url: "https://x.example", tags: ["#kult41"] });
     assert.ok(r[0].tags.includes("#kult41"));
   });
+
+  it("keeps an all-day event happening today (not dropped as past)", () => {
+    const t = new Date();
+    const midnightToday = new Date(t.getFullYear(), t.getMonth(), t.getDate());
+    const events = [mkEvent({ allDay: true, dtstart: midnightToday, uid: "allday-today" })];
+    const r = toCards(events, { name: "X", url: "https://x.example" });
+    assert.equal(r.length, 1);
+  });
+
+  it("still drops an all-day event from yesterday", () => {
+    const t = new Date();
+    const yesterday = new Date(t.getFullYear(), t.getMonth(), t.getDate() - 1);
+    const events = [mkEvent({ allDay: true, dtstart: yesterday, uid: "allday-past" })];
+    const r = toCards(events, { name: "X", url: "https://x.example" });
+    assert.equal(r.length, 0);
+  });
 });
 
 // ── RSS ───────────────────────────────────────────────────────────────────
@@ -541,13 +597,30 @@ describe("generateRSS", () => {
     assert.match(xml, /&lt;script&gt;/);
   });
 
-  it("uses uid as guid when available", () => {
+  it("uses uid + date/time slot as guid when available", () => {
     const xml = generateRSS([{ ...baseCard, uid: "stable-uid-123" }]);
-    assert.match(xml, /<guid isPermaLink="false">stable-uid-123<\/guid>/);
+    assert.match(xml, /<guid isPermaLink="false">stable-uid-123-20260321T2000<\/guid>/);
   });
 
   it("falls back to date+type guid when no uid", () => {
     const xml = generateRSS([baseCard]);
-    assert.match(xml, /<guid isPermaLink="false">bitcircus101-20260321-special<\/guid>/);
+    assert.match(xml, /<guid isPermaLink="false">bitcircus101-20260321T2000-special<\/guid>/);
+  });
+
+  it("gives recurring instances (shared uid) distinct GUIDs", () => {
+    const xml = generateRSS([
+      { ...baseCard, uid: "weekly@x", date: "2026-03-21", time: "20:00" },
+      { ...baseCard, uid: "weekly@x", date: "2026-03-28", time: "20:00" },
+    ]);
+    const guids = [...xml.matchAll(/<guid[^>]*>([^<]+)<\/guid>/g)].map((m) => m[1]);
+    assert.equal(guids.length, 2);
+    assert.notEqual(guids[0], guids[1]);
+  });
+
+  it("XML-escapes the guid (uid with & and <)", () => {
+    const xml = generateRSS([{ ...baseCard, uid: "a&b<c" }]);
+    assert.match(xml, /<guid isPermaLink="false">a&amp;b&lt;c-20260321T2000<\/guid>/);
+    // no raw, unescaped ampersand anywhere in the feed
+    assert.ok(!/&(?!amp;|lt;|gt;|quot;|#)/.test(xml));
   });
 });


### PR DESCRIPTION
Deep-dive follow-up on calendar aggregation, filtering, display and the RSS feed.

## Correctness (cfb1752)
- **RSS recurring GUID collision** — every instance shared one UID → feed readers collapsed the whole series into one item. Now per-occurrence GUID (`uid-YYYYMMDDThhmm`), and the GUID is XML-escaped.
- **All-day events vanished on the day itself** — `toCards` gated on `> now`; now gated on start-of-day.
- **Attribute injection** — the calendar/event `href` was unescaped (`esc(calHref)`).
- **TZ** — sync jobs pinned to `Europe/Berlin` so floating-local calendar times format correctly and UTC events convert right (runners default to UTC).
- Cross-source dedupe, same-day time sorting, unsupported-`FREQ` warning (+DAILY/YEARLY), upcoming-only "removed" diff, clipboard guard/catch.

## Structure (3ba3c2d)
- **Shared ICS parser** `ics-core.js` (UMD) — one source for Node sync + browser fallback, removes ~150 lines of drift-prone duplication.
- **Pure `aggregate()`** extracted from `main()` — dedupe/sort/cap/firstSeen now unit-tested.
- **Parallel source fetches** with 15s AbortController timeout.
- **RSS deep-links** to `events.html#ev-<slug>`, slug shared via `eventAnchor` so feed and page can't drift.

Tests: 64 → 74 passing.