### PR TITLE
ci(deploy): run E2E in Playwright container, drop fragile browser install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,12 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Browsers + OS deps are baked into the image, so there is no fragile
+    # `playwright install --with-deps` download step (which hung repeatedly and
+    # which caching can't save us from: this site deploys less often than the
+    # 7-day cache-eviction window, so the browser cache is always cold). The tag
+    # MUST match the pinned @playwright/test version in package.json.
+    container: mcr.microsoft.com/playwright:v1.58.2-jammy
     # Match the calendar's Europe/Berlin floating-local times when generating
     # events-data.json / feed.xml and running the (date-sensitive) unit tests.
     env:
@@ -38,21 +44,6 @@ jobs:
             echo "::error::HTML drift: run npm run build:layout and npm run build:logos, then commit."
             exit 1
           )
-
-      - name: Cache Playwright browsers
-        id: pw-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ hashFiles('package-lock.json') }}
-
-      - name: Install Playwright browsers
-        if: steps.pw-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium
-
-      - name: Install Playwright system deps (cache hit)
-        if: steps.pw-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
 
       - name: Run sync-events unit tests
         run: node --test tests/sync-events.spec.mjs

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "bitcircus101",
       "version": "1.0.0",
       "devDependencies": {
-        "@playwright/test": "^1.50.0"
+        "@playwright/test": "1.58.2"
       }
     },
     "node_modules/@playwright/test": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "test:ui": "playwright test --ui"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.0"
+    "@playwright/test": "1.58.2"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -15,10 +15,9 @@ module.exports = defineConfig({
     },
 
     webServer: {
-        // Python's stdlib server (preinstalled on macOS/CI, ThreadingHTTPServer
-        // since 3.7) — same server the README documents for local dev. Avoids
-        // depending on `npx http-server` being fetchable/usable at run time.
-        command: 'python3 -m http.server 8080',
+        // Node static server (tests/serve.mjs). Node is present everywhere we run —
+        // including the Playwright Docker image CI uses, which ships no python3.
+        command: 'node tests/serve.mjs 8080',
         url: 'http://localhost:8080',
         stdout: 'ignore',
         // Reuse :8080 when already serving (avoids bind errors if CI=1 is set locally).

--- a/tests/serve.mjs
+++ b/tests/serve.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * serve.mjs — minimal static file server for the Playwright E2E suite.
+ *
+ * Node is guaranteed in every environment we run tests in (local dev + the
+ * Playwright Docker image used by CI); python3 is NOT in that image, so the
+ * webServer can't rely on `python3 -m http.server`. Serves the repo root.
+ *
+ *   node tests/serve.mjs [port]   # default 8080
+ */
+import { createServer } from "node:http";
+import { readFile, stat } from "node:fs/promises";
+import { join, extname, normalize } from "node:path";
+
+const port = Number(process.argv[2]) || 8080;
+const root = process.cwd();
+
+const TYPES = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".xml": "application/xml; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".ico": "image/x-icon",
+  ".woff2": "font/woff2",
+  ".txt": "text/plain; charset=utf-8",
+  ".webmanifest": "application/manifest+json",
+};
+
+createServer(async (req, res) => {
+  try {
+    let path = decodeURIComponent(req.url.split("?")[0]);
+    if (path.endsWith("/")) path += "index.html";
+    const filePath = normalize(join(root, path));
+    // Block path traversal outside the served root.
+    if (filePath !== root && !filePath.startsWith(root + "/")) {
+      res.writeHead(403).end("Forbidden");
+      return;
+    }
+    const info = await stat(filePath);
+    const target = info.isDirectory() ? join(filePath, "index.html") : filePath;
+    const body = await readFile(target);
+    res.writeHead(200, { "Content-Type": TYPES[extname(target)] || "application/octet-stream" });
+    res.end(body);
+  } catch {
+    res.writeHead(404, { "Content-Type": "text/plain" }).end("Not found");
+  }
+}).listen(port, () => console.log(`static server on http://localhost:${port}`));


### PR DESCRIPTION
The post-merge deploy kept hanging on \`npx playwright install --with-deps chromium\` (~150MB download + apt), on multiple runners, before any test ran.

Caching can't fix it: GitHub evicts caches after **7 days idle** and this site deploys less often than that → the browser cache is always cold → every deploy re-runs the download and is re-exposed to the hang. (Confirmed: \`gh cache list\` was empty; last deploy was 14 days ago.)

## Fix
- **Run the test job in the official Playwright image** (\`mcr.microsoft.com/playwright:v1.58.2-jammy\`) — browsers + OS deps prebaked. No download step, no cache dependency, immune to CDN hiccups. Removes the dead cache + install steps.
- **Pin \`@playwright/test\` to \`1.58.2\`** (exact) so the image tag matches the library version.
- **Replace the \`python3 -m http.server\` webServer** with a tiny Node static server (\`tests/serve.mjs\`) — the image has no python3; Node is guaranteed there and locally. Path/MIME/index/traversal logic verified locally.

Test suite (21 chromium tests × desktop+mobile viewport) is unchanged.