### PR TITLE
ci(deploy): fix git dubious-ownership in container (HTML-drift check)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # The container runs as root but the checkout is owned by the runner uid, so
+      # git refuses the repo ("dubious ownership" → "not a git repository") and the
+      # `git diff` drift check below fails. Mark the workspace trusted first.
+      - name: Trust workspace for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - uses: actions/setup-node@v6
         with:
           node-version: "24"


### PR DESCRIPTION
Follow-up to #17. The containerised test job fixed the Playwright hang, but the `git diff` HTML-drift check then failed with `warning: Not a git repository` — git's dubious-ownership protection kicking in because the container runs as root while the checkout is owned by the runner uid. Not actual HTML drift.

Adds `git config --global --add safe.directory "$GITHUB_WORKSPACE"` after checkout so git trusts the workspace.