### PR TITLE
ci(deploy): skip full E2E+deploy run on doc/meta-only pushes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,17 @@ permissions:
 on:
   push:
     branches: [main]
+    # Doc/meta-only pushes can't change the served site, so skip the full
+    # E2E + deploy run for them (a mixed push touching any other file still
+    # deploys — paths-ignore only skips when EVERY changed path matches).
+    # NOTE: deliberately unlike ci.yml's list — llms.txt is omitted here
+    # because it IS live content and must still trigger a deploy when it
+    # changes; it only sits in ci.yml because it needs no tests.
+    paths-ignore:
+      - "*.md"
+      - "LICENSE"
+      - ".claudeignore"
+      - ".gitignore"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Problem

`deploy.yml` triggers on **every** `push` to main with no `paths` filter. `ci.yml` (the PR gate) already skips `*.md`/meta files, but the deploy didn't — so a doc-only merge (like the just-merged #25, a pure `CLAUDE.md` change) ran the full Playwright × 2 suite **and** a live redeploy for content that never reaches the served site.

## Fix

Add `paths-ignore` to the `push` trigger, mirroring `ci.yml` — with one deliberate difference:

- **No `llms.txt`.** In `ci.yml` it's ignored because it needs no tests, but `llms.txt` *is* live content and **must still deploy** when it changes. Ignoring it here would silently strip llms.txt updates from production. The omission is documented inline so nobody re-adds it "for consistency".

Mechanics that stay intact:
- A **mixed** push touching any non-ignored file still deploys (paths-ignore only skips when *every* changed path matches).
- `workflow_dispatch` is kept → a doc-only redeploy is still possible manually.

## Verified

- Indentation checked byte-for-byte (`cat -A`) against the proven `ci.yml` block — same 2-space structure, no tabs.
- The deploy run this very merge triggers (deploy.yml is not `*.md`, so it runs) is the live validation that the workflow file still parses.